### PR TITLE
Refactor #connection and options={} args and add options specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
-<<<<<<< HEAD
-=======
 api_credentials.env
->>>>>>> c048ab4ad15fbb8636a0e3f85cae1eb2ee0df558

--- a/hubstaff.gemspec
+++ b/hubstaff.gemspec
@@ -6,7 +6,7 @@ require 'hubstaff/version'
 Gem::Specification.new do |spec|
   spec.name          = "hubstaff-ruby"
   spec.version       = Hubstaff::VERSION
-  spec.authors       = ["Smulligan85"]
+  spec.authors       = ["Sean Mulligan"]
   spec.email         = ["sean.mulligan85@gmail.com"]
 
   spec.summary       = %q{Ruby API Wrapper for the Hubstaff API v1}
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday"
   spec.add_dependency "json"
+  spec.add_dependency "dotenv"
 end

--- a/lib/hubstaff.rb
+++ b/lib/hubstaff.rb
@@ -1,8 +1,8 @@
 require "hubstaff/version"
 require "hubstaff/client"
-
-require 'pry'
 require 'dotenv'
+require 'faraday'
+require 'json'
 
 module Hubstaff
   # Your code goes here...

--- a/lib/hubstaff/modules/activity.rb
+++ b/lib/hubstaff/modules/activity.rb
@@ -1,32 +1,16 @@
-require 'faraday'
-require 'json'
-
 class Hubstaff::Client
   module Activity
 
-    def activities(start_time, end_time, orgs="", projects="", users="", offset=0)
+    def activities(start_time, stop_time, options={})
       @activity = connection.get("activities") do |req|
         req.params['start_time'] = start_time
-        req.params['stop_time'] = end_time
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
-        req.params['offset'] = offset
+        req.params['stop_time'] = stop_time
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
+        req.params['offset'] = options[:offset] unless options[:offset].nil?
       end
       @activity_json = JSON.parse(@activity.body)
     end
-
-    private
-
-    def connection
-      Faraday.new(:url => "https://api.hubstaff.com/v1/") do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
-        req.headers['Auth-Token'] = self.auth_token
-        req.headers['App-Token'] = ENV['APP_TOKEN']
-        req.adapter Faraday.default_adapter
-      end
-    end
-
   end
 end

--- a/lib/hubstaff/modules/custom.rb
+++ b/lib/hubstaff/modules/custom.rb
@@ -1,110 +1,94 @@
-require 'pry'
-require 'faraday'
-require 'json'
-
 class Hubstaff::Client
   module Custom
 
-    def custom_date_team(start_time, end_time, orgs="", projects="", users="", show_tasks=false, show_notes=false, show_activity=false, include_archieved=false)
+    def custom_date_team(start_date, end_date, options={})
       @custom_date_team = connection.get("custom/by_date/team") do |req|
-        req.params['start_time'] = start_time
-        req.params['stop_time'] = end_time
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
-        req.params['show_tasks'] = show_tasks
-        req.params['show_notes'] = show_notes
-        req.params['show_activity'] = show_activity
-        req.params['include_archieved'] = include_archieved
+        req.params['start_date'] = start_date
+        req.params['end_date'] = end_date
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
+        req.params['show_tasks'] = options[:show_tasks] unless options[:show_tasks].nil?
+        req.params['show_notes'] = options[:show_notes] unless options[:show_notes].nil?
+        req.params['show_activity'] = options[:show_activity] unless options[:show_activity].nil?
+        req.params['include_archieved'] = options[:include_archieved] unless options[:include_archieved].nil?
       end
       @custom_date_team_json = JSON.parse(@custom_date_team.body)
     end
 
-    def custom_date_my(start_time, end_time, orgs="", projects="", users="", show_tasks=false, show_notes=false, show_activity=false, include_archieved=false)
+    def custom_date_my(start_date, end_date, options={})
       @custom_date_my = connection.get("custom/by_date/my") do |req|
-        req.params['start_time'] = start_time
-        req.params['stop_time'] = end_time
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
-        req.params['show_tasks'] = show_tasks
-        req.params['show_notes'] = show_notes
-        req.params['show_activity'] = show_activity
-        req.params['include_archieved'] = include_archieved
+        req.params['start_date'] = start_date
+        req.params['end_date'] = end_date
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
+        req.params['show_tasks'] = options[:show_tasks] unless options[:show_tasks].nil?
+        req.params['show_notes'] = options[:show_notes] unless options[:show_notes].nil?
+        req.params['show_activity'] = options[:show_activity] unless options[:show_activity].nil?
+        req.params['include_archieved'] = options[:include_archieved] unless options[:include_archieved].nil?
       end
       @custom_date_my_json = JSON.parse(@custom_date_my.body)
     end
 
-    def custom_member_team(start_time, end_time, orgs="", projects="", users="", show_tasks=false, show_notes=false, show_activity=false, include_archieved=false)
+    def custom_member_team(start_date, end_date, options={})
       @custom_member_team = connection.get("custom/by_member/team") do |req|
-        req.params['start_time'] = start_time
-        req.params['stop_time'] = end_time
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
-        req.params['show_tasks'] = show_tasks
-        req.params['show_notes'] = show_notes
-        req.params['show_activity'] = show_activity
-        req.params['include_archieved'] = include_archieved
+        req.params['start_date'] = start_date
+        req.params['end_date'] = end_date
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
+        req.params['show_tasks'] = options[:show_tasks] unless options[:show_tasks].nil?
+        req.params['show_notes'] = options[:show_notes] unless options[:show_notes].nil?
+        req.params['show_activity'] = options[:show_activity] unless options[:show_activity].nil?
+        req.params['include_archieved'] = options[:include_archieved] unless options[:include_archieved].nil?
       end
       @custom_member_team_json = JSON.parse(@custom_member_team.body)
     end
 
-    def custom_member_my(start_time, end_time, orgs="", projects="", users="", show_tasks=false, show_notes=false, show_activity=false, include_archieved=false)
+    def custom_member_my(start_date, end_date, options={})
       @custom_member_my = connection.get("custom/by_member/my") do |req|
-        req.params['start_time'] = start_time
-        req.params['stop_time'] = end_time
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
-        req.params['show_tasks'] = show_tasks
-        req.params['show_notes'] = show_notes
-        req.params['show_activity'] = show_activity
-        req.params['include_archieved'] = include_archieved
+        req.params['start_date'] = start_date
+        req.params['end_date'] = end_date
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
+        req.params['show_tasks'] = options[:show_tasks] unless options[:show_tasks].nil?
+        req.params['show_notes'] = options[:show_notes] unless options[:show_notes].nil?
+        req.params['show_activity'] = options[:show_activity] unless options[:show_activity].nil?
+        req.params['include_archieved'] = options[:include_archieved] unless options[:include_archieved].nil?
       end
       @custom_member_my_json = JSON.parse(@custom_member_my.body)
     end
 
-    def custom_project_team(start_time, end_time, orgs="", projects="", users="", show_tasks=false, show_notes=false, show_activity=false, include_archieved=false)
+    def custom_project_team(start_date, end_date, options={})
       @custom_project_team = connection.get("custom/by_project/team") do |req|
-        req.params['start_time'] = start_time
-        req.params['stop_time'] = end_time
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
-        req.params['show_tasks'] = show_tasks
-        req.params['show_notes'] = show_notes
-        req.params['show_activity'] = show_activity
-        req.params['include_archieved'] = include_archieved
+        req.params['start_date'] = start_date
+        req.params['end_date'] = end_date
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
+        req.params['show_tasks'] = options[:show_tasks] unless options[:show_tasks].nil?
+        req.params['show_notes'] = options[:show_notes] unless options[:show_notes].nil?
+        req.params['show_activity'] = options[:show_activity] unless options[:show_activity].nil?
+        req.params['include_archieved'] = options[:include_archieved] unless options[:include_archieved].nil?
       end
       @custom_project_team_json = JSON.parse(@custom_project_team.body)
     end
 
-    def custom_project_my(start_time, end_time, orgs="", projects="", users="", show_tasks=false, show_notes=false, show_activity=false, include_archieved=false)
+    def custom_project_my(start_date, end_date, options={})
       @custom_project_my = connection.get("custom/by_project/my") do |req|
-        req.params['start_time'] = start_time
-        req.params['stop_time'] = end_time
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
-        req.params['show_tasks'] = show_tasks
-        req.params['show_notes'] = show_notes
-        req.params['show_activity'] = show_activity
-        req.params['include_archieved'] = include_archieved
+        req.params['start_date'] = start_date
+        req.params['end_date'] = end_date
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
+        req.params['show_tasks'] = options[:show_tasks] unless options[:show_tasks].nil?
+        req.params['show_notes'] = options[:show_notes] unless options[:show_notes].nil?
+        req.params['show_activity'] = options[:show_activity] unless options[:show_activity].nil?
+        req.params['include_archieved'] = options[:include_archieved] unless options[:include_archieved].nil?
       end
       @custom_project_my_json = JSON.parse(@custom_project_my.body)
-    end
-
-    private
-
-    def connection
-      Faraday.new(:url => "https://api.hubstaff.com/v1/") do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
-        req.headers['Auth-Token'] = self.auth_token
-        req.headers['App-Token'] = ENV['APP_TOKEN']
-        req.adapter Faraday.default_adapter
-      end
     end
   end
 end

--- a/lib/hubstaff/modules/note.rb
+++ b/lib/hubstaff/modules/note.rb
@@ -1,42 +1,21 @@
-require 'pry'
-require 'faraday'
-require 'json'
-
 class Hubstaff::Client
   module Note
 
-    def notes(start_time, end_time, orgs="", projects="", users="", offset=0)
+    def notes(start_time, stop_time, options={})
       @notes = connection.get("notes") do |req|
         req.params['start_time'] = start_time
-        req.params['stop_time'] = end_time
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
-        req.params['offset'] = offset
+        req.params['stop_time'] = stop_time
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
+        req.params['offset'] = options[:offset] unless options[:offset].nil?
       end
       @note_json = JSON.parse(@notes.body)
     end
 
     def find_note(note_id)
-      @note = get_note("notes/#{note_id}")
+      @note = get_json("notes/#{note_id}")
     end
-
-    private
-
-    def connection
-      Faraday.new(:url => "https://api.hubstaff.com/v1/") do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
-        req.headers['Auth-Token'] = self.auth_token
-        req.headers['App-Token'] = ENV['APP_TOKEN']
-        req.adapter Faraday.default_adapter
-      end
-    end
-
-    def get_note(url)
-      JSON.parse(connection.get(url).body)
-    end
-
   end
 end
 

--- a/lib/hubstaff/modules/organization.rb
+++ b/lib/hubstaff/modules/organization.rb
@@ -1,6 +1,3 @@
-require 'faraday'
-require 'json'
-
 class Hubstaff::Client
   module Organization
 
@@ -12,7 +9,7 @@ class Hubstaff::Client
     end
 
     def find_organization(org_id)
-      @found_org = get_url("organizations/#{org_id}")
+      @found_org = get_json("organizations/#{org_id}")
     end
 
     def find_org_projects(org_id, offset=0)
@@ -27,22 +24,6 @@ class Hubstaff::Client
         req.params['offset'] = offset
       end
       @org_member_json = JSON.parse(@org_members.body)
-    end
-
-    private
-
-    def connection
-      Faraday.new(:url => "https://api.hubstaff.com/v1/") do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
-        req.headers['Auth-Token'] = self.auth_token
-        req.headers['App-Token'] = ENV['APP_TOKEN']
-        req.adapter Faraday.default_adapter
-      end
-    end
-
-    def get_url(url)
-      JSON.parse(connection.get(url).body)
     end
   end
 end

--- a/lib/hubstaff/modules/project.rb
+++ b/lib/hubstaff/modules/project.rb
@@ -1,6 +1,3 @@
-require 'faraday'
-require 'json'
-
 class Hubstaff::Client
   module Project
 
@@ -19,7 +16,7 @@ class Hubstaff::Client
     end
 
     def find_project(project_id)
-      @project = get_project("projects/#{project_id}")
+      @project = get_json("projects/#{project_id}")
     end
 
     def find_project_members(project_id, offset=0)
@@ -27,22 +24,6 @@ class Hubstaff::Client
         req.params['offset'] = offset
       end
       @members_json = JSON.parse(@members.body)
-    end
-
-    private
-
-    def connection
-      Faraday.new(:url => "https://api.hubstaff.com/v1") do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
-        req.headers['Auth-Token'] = self.auth_token
-        req.headers['App-Token'] = ENV['APP_TOKEN']
-        req.adapter Faraday.default_adapter
-      end
-    end
-
-    def get_project(url)
-      JSON.parse(connection.get(url).body)
     end
   end
 end

--- a/lib/hubstaff/modules/screenshot.rb
+++ b/lib/hubstaff/modules/screenshot.rb
@@ -1,32 +1,16 @@
-require 'pry'
-require 'faraday'
-require 'json'
-
 class Hubstaff::Client
   module Screenshot
 
-  def screenshots(start_time, end_time, orgs="", projects="", users="", offset=0)
-      @screenshot = connection.get("screenshots") do |req|
-        req.params['start_time'] = start_time
-        req.params['stop_time'] = end_time
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
-        req.params['offset'] = offset
-      end
-      @screenshot_json = JSON.parse(@screenshot.body)
-  end
-
-    private
-
-    def connection
-      Faraday.new(:url => "https://api.hubstaff.com/v1/") do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
-        req.headers['Auth-Token'] = self.auth_token
-        req.headers['App-Token'] = ENV['APP_TOKEN']
-        req.adapter Faraday.default_adapter
-      end
+    def screenshots(start_time, stop_time, options={})
+        @screenshot = connection.get("screenshots") do |req|
+          req.params['start_time'] = start_time
+          req.params['stop_time'] = stop_time
+          req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+          req.params['projects'] = options[:projects] unless options[:projects].nil?
+          req.params['users'] = options[:users] unless options[:users].nil?
+          req.params['offset'] = options[:offset] unless options[:offset].nil?
+        end
+        @screenshot_json = JSON.parse(@screenshot.body)
     end
   end
 end

--- a/lib/hubstaff/modules/task.rb
+++ b/lib/hubstaff/modules/task.rb
@@ -1,7 +1,3 @@
-require 'pry'
-require 'faraday'
-require 'json'
-
 class Hubstaff::Client
   module Task
 
@@ -14,24 +10,7 @@ class Hubstaff::Client
     end
 
     def find_task(task_id)
-      @task = get_task("tasks/#{task_id}")
+      @task = get_json("tasks/#{task_id}")
     end
-
-    private
-
-    def connection
-      Faraday.new(:url => "https://api.hubstaff.com/v1/") do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
-        req.headers['Auth-Token'] = self.auth_token
-        req.headers['App-Token'] = ENV['APP_TOKEN']
-        req.adapter Faraday.default_adapter
-      end
-    end
-
-    def get_task(url)
-      JSON.parse(connection.get(url).body)
-    end
-
   end
 end

--- a/lib/hubstaff/modules/user.rb
+++ b/lib/hubstaff/modules/user.rb
@@ -1,6 +1,3 @@
-require 'faraday'
-require 'json'
-
 class Hubstaff::Client
   module User
 
@@ -14,7 +11,7 @@ class Hubstaff::Client
     end
 
     def find_user(user_id)
-      @user = get_user("users/#{user_id}")
+      @user = get_json("users/#{user_id}")
     end
 
     def find_user_orgs(user_id, offset=0)
@@ -29,22 +26,6 @@ class Hubstaff::Client
         req.params['offset'] = offset
       end
       @user_projects = JSON.parse(@projects.body)
-    end
-
-    private
-
-    def connection
-      Faraday.new(:url => "https://api.hubstaff.com/v1/") do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
-        req.headers['Auth-Token'] = self.auth_token
-        req.headers['App-Token'] = ENV['APP_TOKEN']
-        req.adapter Faraday.default_adapter
-      end
-    end
-
-    def get_user(url)
-      JSON.parse(connection.get(url).body)
     end
   end
 end

--- a/lib/hubstaff/modules/weekly.rb
+++ b/lib/hubstaff/modules/weekly.rb
@@ -1,40 +1,24 @@
-require 'pry'
-require 'faraday'
-require 'json'
-
 class Hubstaff::Client
   module Weekly
 
-    def weekly_team(date="", orgs="", projects="", users="")
+    def weekly_team(options={})
       @weekly_team_report = connection.get("weekly/team") do |req|
-        req.params['date'] = date unless date.empty?
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
+        req.params['date'] = options[:date] unless options[:date].nil?
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
       end
       @weekly_team_json = JSON.parse(@weekly_team_report.body)
     end
 
-    def weekly_my(date="", orgs="", projects="", users="")
+    def weekly_my(options={})
       @weekly_team_report = connection.get("weekly/my") do |req|
-        req.params['date'] = date unless date.empty?
-        req.params['organizations'] = orgs unless orgs.empty?
-        req.params['projects'] = projects unless projects.empty?
-        req.params['users'] = users unless users.empty?
+        req.params['date'] = options[:date] unless options[:date].nil?
+        req.params['organizations'] = options[:orgs] unless options[:orgs].nil?
+        req.params['projects'] = options[:projects] unless options[:projects].nil?
+        req.params['users'] = options[:users] unless options[:users].nil?
       end
       @weekly_team_json = JSON.parse(@weekly_team_report.body)
-    end
-
-    private
-
-    def connection
-      Faraday.new(:url => "https://api.hubstaff.com/v1/") do |req|
-        req.headers['Content-Type'] = 'application/json'
-        req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
-        req.headers['Auth-Token'] = self.auth_token
-        req.headers['App-Token'] = ENV['APP_TOKEN']
-        req.adapter Faraday.default_adapter
-      end
     end
   end
 end

--- a/spec/hubstaff/modules/activities_module_spec.rb
+++ b/spec/hubstaff/modules/activities_module_spec.rb
@@ -7,9 +7,26 @@ class Hubstaff::Client
     end
 
     describe '#activities' do
-      it "returns a collection of activities" do
-        expect(@client.activities("2016-05-24", "2016-05-24", "27572, 27573")).to be_an_instance_of(Hash)
+      it "returns a collection of all activities" do
+        expect(@client.activities("2016-05-24", "2016-05-24")).to be_an_instance_of(Hash)
       end
+
+      it "returns a collection of activities for a specific org" do
+        expect(@client.activities("2016-05-24", "2016-05-24", orgs: "27572")).to be_an_instance_of(Hash)
+      end
+
+      it "returns a collection of activities for a specific project" do
+        expect(@client.activities("2016-05-24", "2016-05-24", projects: "112761")).to be_an_instance_of(Hash)
+      end
+
+      it "returns a collection of activities for a specific user" do
+        expect(@client.activities("2016-05-24", "2016-05-24", users: "61188")).to be_an_instance_of(Hash)
+      end
+
+      it "returns a collection of activities starting at a offset" do
+        expect(@client.activities("2016-05-24", "2016-05-24", offset: 0)).to be_an_instance_of(Hash)
+      end
+
     end
   end
 end

--- a/spec/hubstaff/modules/custom_module_spec.rb
+++ b/spec/hubstaff/modules/custom_module_spec.rb
@@ -7,42 +7,208 @@ class Hubstaff::Client
     end
 
     describe '#custom_date_team' do
-      it "returns a custom team report by date" do
-        expect(@client.custom_date_team("2016-05-23", "2016-05-25")).to be_an_instance_of(Hash)
+      it "returns a custom team report grouped by date" do
+        expect(@client.custom_date_team("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+      end
+
+      it "returns a custom team report grouped by date and specific organizations" do
+        expect(@client.custom_date_team("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report grouped by date and specific projects" do
+        expect(@client.custom_date_team("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report grouped by date and specific users" do
+        expect(@client.custom_date_team("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+      
+      it "returns a custom team report grouped by date and show tasks" do
+        expect(@client.custom_date_team("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+      
+      it "returns a custom team report grouped by date and show notes" do
+        expect(@client.custom_date_team("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+      
+      it "returns a custom team report grouped by date and show archieved" do
+        expect(@client.custom_date_team("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+      
+      it "returns a custom team report grouped by date and show tasks" do
+        expect(@client.custom_date_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
       end
     end
 
     describe '#custom_date_my' do
       it "returns a custom individual report by date" do
-        expect(@client.custom_date_my("2016-05-23", "2016-05-25")).to be_an_instance_of(Hash)
+        expect(@client.custom_date_my("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+      end
+
+      it "returns a custom individual report grouped by date and specific organizations" do
+        expect(@client.custom_date_my("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report grouped by date and specific projects" do
+        expect(@client.custom_date_my("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report grouped by date and specific users" do
+        expect(@client.custom_date_my("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report grouped by date and show tasks" do
+        expect(@client.custom_date_my("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report grouped by date and show notes" do
+        expect(@client.custom_date_my("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report grouped by date and show archieved" do
+        expect(@client.custom_date_my("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report grouped by date and show tasks" do
+        expect(@client.custom_date_my("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
       end
     end
 
     describe '#custom_member_team' do
-      it "returns a custom team report by member" do
-        expect(@client.custom_member_team("2016-05-23", "2016-05-25")).to be_an_instance_of(Hash)
+      it "returns a custom team report group by member" do
+        expect(@client.custom_member_team("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+      end
+
+      it "returns a custom team report group by member and specific organizations" do
+        expect(@client.custom_member_team("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by member and specific projects" do
+        expect(@client.custom_member_team("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by member and specific users" do
+        expect(@client.custom_member_team("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by member and show tasks" do
+        expect(@client.custom_member_team("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by member and show notes" do
+        expect(@client.custom_member_team("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by member and show archieved" do
+        expect(@client.custom_member_team("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by member and show tasks" do
+        expect(@client.custom_member_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
       end
     end
 
     describe '#custom_member_my' do
-      it "returns a custom individual report by member" do
-        expect(@client.custom_member_my("2016-05-23", "2016-05-25")).to be_an_instance_of(Hash)
+      it "returns a custom individual report group by member" do
+        expect(@client.custom_member_my("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+      end
+
+      it "returns a custom individual report group by member and specific organizations" do
+        expect(@client.custom_member_my("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by member and specific projects" do
+        expect(@client.custom_member_my("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by member and specific users" do
+        expect(@client.custom_member_my("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by member and show tasks" do
+        expect(@client.custom_member_my("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by member and show notes" do
+        expect(@client.custom_member_my("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by member and show archieved" do
+        expect(@client.custom_member_my("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by member and show tasks" do
+        expect(@client.custom_member_my("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
       end
     end
 
     describe '#custom_project_team' do
-      it "returns a custom team report by project" do
-        expect(@client.custom_project_team("2016-05-23", "2016-05-25")).to be_an_instance_of(Hash)
+      it "returns a custom team report group by project" do
+        expect(@client.custom_project_team("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+      end
+
+      it "returns a custom team report group by project and specific organizations" do
+        expect(@client.custom_project_team("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by project and specific projects" do
+        expect(@client.custom_project_team("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by project and specific users" do
+        expect(@client.custom_project_team("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by project and show tasks" do
+        expect(@client.custom_project_team("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by project and show notes" do
+        expect(@client.custom_project_team("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by project and show archieved" do
+        expect(@client.custom_project_team("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom team report group by project and show tasks" do
+        expect(@client.custom_project_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
       end
     end
 
     describe '#custom_project_my' do
-      it "returns a custom individual report by project" do
-        expect(@client.custom_project_my("2016-05-23", "2016-05-25")).to be_an_instance_of(Hash)
+      it "returns a custom individual report group by project" do
+        expect(@client.custom_project_my("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+      end
+
+      it "returns a custom individual report group by project and specific organizations" do
+        expect(@client.custom_project_my("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by project and specific projects" do
+        expect(@client.custom_project_my("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by project and specific users" do
+        expect(@client.custom_project_my("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by project and show tasks" do
+        expect(@client.custom_project_my("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by project and show notes" do
+        expect(@client.custom_project_my("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by project and show archieved" do
+        expect(@client.custom_project_my("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a custom individual report group by project and show tasks" do
+        expect(@client.custom_project_my("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
       end
     end
 
   end
 end
-
-

--- a/spec/hubstaff/modules/notes_module_spec.rb
+++ b/spec/hubstaff/modules/notes_module_spec.rb
@@ -10,14 +10,29 @@ class Hubstaff::Client
       it "returns a collection of notes" do
         expect(@client.notes("2016-05-23", "2016-05-25")['notes']).to be_an_instance_of(Array)
       end
+
+      it "returns a collection of notes for a specific organization" do
+        expect(@client.notes("2016-05-23", "2016-05-25", orgs: "27572")["notes"][0]["description"]).to eq("Practice Notes")
+      end
+
+      it "returns a collection of notes for a specific project" do
+        expect(@client.notes("2016-05-23", "2016-05-25", projects: "112761")["notes"][0]["description"]).to eq("Practice Notes")
+      end
+
+      it "returns a collection of notes for a specific user" do
+        expect(@client.notes("2016-05-23", "2016-05-25", users: "61188")["notes"][0]["description"]).to eq("Practice Notes")
+      end
+
+      it "returns a collection of notes with a offset" do
+        expect(@client.notes("2016-05-23", "2016-05-25", offset: 0)["notes"][0]["description"]).to eq("Practice Notes")
+      end
     end
 
     describe '#find_note' do
       it "returns a specific note" do
-        expect(@client.find_note(716530)).to be_an_instance_of(Hash)
+        expect(@client.find_note(716530)["note"]["description"]).to eq("Practice Notes")
       end
     end
 
   end
 end
-

--- a/spec/hubstaff/modules/screenshot_module_spec.rb
+++ b/spec/hubstaff/modules/screenshot_module_spec.rb
@@ -2,11 +2,29 @@
 #
 # class Hubstaff::Client
 #   describe Screenshot do
+#       before(:each) do
+#       @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+#     end
 #
 #     describe '#screenshots' do
 #       it "returns a collection of screenshots" do
-#         @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
 #         expect(@client.screenshots("2016-05-24", "2016-05-24")).to be_an_instance_of(Hash)
+#       end
+#
+#       it "returns a collection of screenshots for a specific orgnaization" do
+#         expect(@client.screenshots("2016-05-24", "2016-05-24", orgs: "27572")).to be_an_instance_of(Hash)
+#       end
+#
+#       it "returns a collection of screenshots for a specific project" do
+#         expect(@client.screenshots("2016-05-24", "2016-05-24", projects: "112761")).to be_an_instance_of(Hash)
+#       end
+#
+#       it "returns a collection of screenshots for a specific user" do
+#         expect(@client.screenshots("2016-05-24", "2016-05-24", users: "61188")).to be_an_instance_of(Hash)
+#       end
+#
+#       it "returns a collection of screenshots with a offset" do
+#         expect(@client.screenshots("2016-05-24", "2016-05-24", offset: 0)).to be_an_instance_of(Hash)
 #       end
 #     end
 #   end

--- a/spec/hubstaff/modules/task_module_spec.rb
+++ b/spec/hubstaff/modules/task_module_spec.rb
@@ -7,18 +7,24 @@
 #     end
 #
 #     describe '#tasks' do
-#       it "returns a collection of notes" do
+#       it "returns a collection of tasks" do
 #         expect(@client.tasks).to be_an_instance_of(Array)
+#       end
+#
+#       it "returns a collection of tasks for a specific project" do
+#         expect(@client.tasks(projects: "112761")).to be_an_instance_of(Hash)
+#       end
+#
+#       it "returns a collection of tasks with a offset" do
+#         expect(@client.tasks(offset: 0)).to be_an_instance_of(Hash)
 #       end
 #     end
 #
 #     describe '#find_task' do
-#       it "returns a specific note" do
+#       it "returns a specific task" do
 #         expect(@client.find_task(716530)).to be_an_instance_of(Hash)
 #       end
 #     end
 #
 #   end
 # end
-#
-#

--- a/spec/hubstaff/modules/weekly_module_spec.rb
+++ b/spec/hubstaff/modules/weekly_module_spec.rb
@@ -7,18 +7,49 @@ class Hubstaff::Client
     end
 
     describe '#weekly_team' do
-      it "returns a weekly team report" do
-        expect(@client.weekly_team("2016-05-24")).to be_an_instance_of(Hash)
+      it "returns a weekly team report with default settings" do
+        expect(@client.weekly_team["organizations"]).to be_an_instance_of(Array)
       end
+
+      it "returns a weekly team report with a specific date in week" do
+        expect(@client.weekly_team(date: "2016-05-24")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a weekly team report with a specific orgnaization" do
+        expect(@client.weekly_team(date: "2016-05-24", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a weekly team report with a specific project" do
+        expect(@client.weekly_team(date: "2016-05-24", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a weekly team report with a specific user" do
+        expect(@client.weekly_team(date: "2016-05-24", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+ 
     end
 
     describe '#weekly_my' do
-      it "returns a weekly individual report" do
-        expect(@client.weekly_my("2016-05-24")).to be_an_instance_of(Hash)
+      it "returns a weekly individual report with default settings" do
+        expect(@client.weekly_my["organizations"]).to be_an_instance_of(Array)
+      end
+
+      it "returns a weekly individual report with a specific date in week" do
+        expect(@client.weekly_my(date: "2016-05-24")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a weekly individual report with a specific orgnaization" do
+        expect(@client.weekly_my(date: "2016-05-24", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a weekly individual report with a specific project" do
+        expect(@client.weekly_my(date: "2016-05-24", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+      end
+
+      it "returns a weekly individual report with a specific user" do
+        expect(@client.weekly_my(date: "2016-05-24", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
       end
     end
 
   end
 end
-
-


### PR DESCRIPTION
1. DRY'd up #connection by centralizing within Client
2. Added options hash for the get request params options
3. Added additional specs to test for different option params.