### PR TITLE
Remove dotenv dependency and add VCR recording to specs

### DIFF
--- a/hubstaff.gemspec
+++ b/hubstaff.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "vcr", "~> 3.0", ">= 3.0.3"
   spec.add_development_dependency "dotenv", "~> 2.1"
   spec.add_development_dependency "pry", "~> 0.10.3"
 

--- a/lib/hubstaff.rb
+++ b/lib/hubstaff.rb
@@ -1,6 +1,5 @@
 require "hubstaff/version"
 require "hubstaff/client"
-require 'dotenv'
 require 'faraday'
 require 'json'
 

--- a/lib/hubstaff/client.rb
+++ b/lib/hubstaff/client.rb
@@ -11,22 +11,21 @@ class Hubstaff::Client
   include Task
   include Custom
 
-  attr_reader :auth_token
+  attr_accessor :auth_token, :app_token
 
-  def initialize(email, password, auth_token=nil)
-    @auth_token = auth_token || self.authenticate_client_and_return_auth_token(email, password)
+  def initialize(app_token)
+    @app_token = app_token
   end
 
-  def authenticate_client_and_return_auth_token(email, password)
+  def authenticate(email, password)
     response ||= Faraday.post do |req|
       req.url "https://api.hubstaff.com/v1/auth"
       req.headers['Content-Type'] = 'application/json'
-      req.headers['App-Token'] = ENV['APP_TOKEN']
+      req.headers['App-Token'] = self.app_token
       req.params['email'] = email
       req.params['password'] = password
     end
-    auth_token = JSON.parse(response.body)['user']['auth_token']
-    auth_token
+    self.auth_token = JSON.parse(response.body)['user']['auth_token']
   end
 
   def connection
@@ -34,7 +33,7 @@ class Hubstaff::Client
       req.headers['Content-Type'] = 'application/json'
       req.headers['User-Agent'] = "Hubstaff-Ruby v#{Hubstaff::VERSION}"
       req.headers['Auth-Token'] = self.auth_token
-      req.headers['App-Token'] = ENV['APP_TOKEN']
+      req.headers['App-Token'] = self.app_token
       req.adapter Faraday.default_adapter
     end
   end

--- a/spec/hubstaff/client_spec.rb
+++ b/spec/hubstaff/client_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 
 module Hubstaff
   describe Client do
-    before(:each) do 
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+    before(:each) do
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
     end
-    describe  "#authenticate_client_and_return_auth_token" do
+    describe  "#authenticate" do
       it "returns the users auth_token" do
-        expect(@client.auth_token).to eq(ENV['AUTH_TOKEN'])
+        VCR.use_cassette 'api/client' do
+          expect(@client.authenticate(ENV['APP_EMAIL'], ENV['APP_PASSWORD'])).to eq(ENV['AUTH_TOKEN'])
+        end
       end
     end
   end

--- a/spec/hubstaff/modules/activities_module_spec.rb
+++ b/spec/hubstaff/modules/activities_module_spec.rb
@@ -3,28 +3,39 @@ require 'spec_helper'
 class Hubstaff::Client
   describe Activity do
     before(:each) do
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
+      @client.auth_token = ENV['AUTH_TOKEN']
     end
 
     describe '#activities' do
       it "returns a collection of all activities" do
-        expect(@client.activities("2016-05-24", "2016-05-24")).to be_an_instance_of(Hash)
+        VCR.use_cassette 'activity/activities' do
+          expect(@client.activities("2016-05-24", "2016-05-24")).to be_an_instance_of(Hash)
+        end
       end
 
       it "returns a collection of activities for a specific org" do
-        expect(@client.activities("2016-05-24", "2016-05-24", orgs: "27572")).to be_an_instance_of(Hash)
+        VCR.use_cassette 'activity/activities_org' do
+          expect(@client.activities("2016-05-24", "2016-05-24", orgs: "27572")).to be_an_instance_of(Hash)
+        end
       end
 
       it "returns a collection of activities for a specific project" do
-        expect(@client.activities("2016-05-24", "2016-05-24", projects: "112761")).to be_an_instance_of(Hash)
+        VCR.use_cassette 'activity/activities_project' do
+          expect(@client.activities("2016-05-24", "2016-05-24", projects: "112761")).to be_an_instance_of(Hash)
+        end
       end
 
       it "returns a collection of activities for a specific user" do
-        expect(@client.activities("2016-05-24", "2016-05-24", users: "61188")).to be_an_instance_of(Hash)
+        VCR.use_cassette 'activity/activites_user' do
+          expect(@client.activities("2016-05-24", "2016-05-24", users: "61188")).to be_an_instance_of(Hash)
+        end
       end
 
       it "returns a collection of activities starting at a offset" do
-        expect(@client.activities("2016-05-24", "2016-05-24", offset: 0)).to be_an_instance_of(Hash)
+        VCR.use_cassette 'activity/activites_offset' do
+          expect(@client.activities("2016-05-24", "2016-05-24", offset: 0)).to be_an_instance_of(Hash)
+        end
       end
     end
   end

--- a/spec/hubstaff/modules/custom_module_spec.rb
+++ b/spec/hubstaff/modules/custom_module_spec.rb
@@ -3,210 +3,314 @@ require 'spec_helper'
 class Hubstaff::Client
   describe Custom do
     before(:each) do
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
+      @client.auth_token = ENV['AUTH_TOKEN']
     end
 
     describe '#custom_date_team' do
       it "returns a custom team report grouped by date" do
-        expect(@client.custom_date_team("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        VCR.use_cassette 'custom/custom_data_team_date' do
+          expect(@client.custom_date_team("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        end
       end
 
       it "returns a custom team report grouped by date and specific organizations" do
-        expect(@client.custom_date_team("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_team_date_and_org' do
+          expect(@client.custom_date_team("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report grouped by date and specific projects" do
-        expect(@client.custom_date_team("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_team_date_and_project' do
+          expect(@client.custom_date_team("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report grouped by date and specific users" do
-        expect(@client.custom_date_team("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_team_date_and_user' do
+          expect(@client.custom_date_team("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
       
       it "returns a custom team report grouped by date and show tasks" do
-        expect(@client.custom_date_team("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_team_date_and_task' do
+          expect(@client.custom_date_team("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
       
       it "returns a custom team report grouped by date and show notes" do
-        expect(@client.custom_date_team("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_team_date_and_note' do
+          expect(@client.custom_date_team("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
+      end
+      
+      it "returns a custom team report grouped by date and show activities" do
+        VCR.use_cassette 'custom/custom_data_team_date_and_activity' do
+          expect(@client.custom_date_team("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
       
       it "returns a custom team report grouped by date and show archieved" do
-        expect(@client.custom_date_team("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_team_date_and_archieve' do
+          expect(@client.custom_date_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
-      
-      it "returns a custom team report grouped by date and show tasks" do
-        expect(@client.custom_date_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+
+      it "returns a custom team report grouped by date and show archieved" do
+        VCR.use_cassette 'custom/custom_data_team_date_and_archieve' do
+          expect(@client.custom_date_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
+
     end
 
     describe '#custom_date_my' do
       it "returns a custom individual report by date" do
-        expect(@client.custom_date_my("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        VCR.use_cassette 'custom/custom_data_my_date' do
+          expect(@client.custom_date_my("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        end
       end
 
       it "returns a custom individual report grouped by date and specific organizations" do
-        expect(@client.custom_date_my("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_my_date_and_orgs' do
+          expect(@client.custom_date_my("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report grouped by date and specific projects" do
-        expect(@client.custom_date_my("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_my_date_and_projects' do
+          expect(@client.custom_date_my("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report grouped by date and specific users" do
-        expect(@client.custom_date_my("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_my_date_and_user' do
+          expect(@client.custom_date_my("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report grouped by date and show tasks" do
-        expect(@client.custom_date_my("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_my_date_and_task' do
+          expect(@client.custom_date_my("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report grouped by date and show notes" do
-        expect(@client.custom_date_my("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_my_date_and_note' do
+          expect(@client.custom_date_my("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
+      end
+
+      it "returns a custom individual report grouped by date and show activity" do
+        VCR.use_cassette 'custom/custom_data_my_date_and_activity' do
+          expect(@client.custom_date_my("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report grouped by date and show archieved" do
-        expect(@client.custom_date_my("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
-      end
-
-      it "returns a custom individual report grouped by date and show tasks" do
-        expect(@client.custom_date_my("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_data_my_date_and_archieve' do
+          expect(@client.custom_date_my("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
     end
 
     describe '#custom_member_team' do
       it "returns a custom team report group by member" do
-        expect(@client.custom_member_team("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        VCR.use_cassette 'custom/custom_team_member' do
+          expect(@client.custom_member_team("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        end
       end
 
       it "returns a custom team report group by member and specific organizations" do
-        expect(@client.custom_member_team("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_member_and_org' do
+          expect(@client.custom_member_team("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by member and specific projects" do
-        expect(@client.custom_member_team("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_member_and_project' do
+          expect(@client.custom_member_team("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by member and specific users" do
-        expect(@client.custom_member_team("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_member_and_user' do
+          expect(@client.custom_member_team("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by member and show tasks" do
-        expect(@client.custom_member_team("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_member_and_task' do
+          expect(@client.custom_member_team("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by member and show notes" do
-        expect(@client.custom_member_team("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_member_and_note' do
+          expect(@client.custom_member_team("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
+      end
+
+      it "returns a custom team report group by member and show activities" do
+        VCR.use_cassette 'custom/custom_team_member_and_activity' do
+          expect(@client.custom_member_team("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by member and show archieved" do
-        expect(@client.custom_member_team("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
-      end
-
-      it "returns a custom team report group by member and show tasks" do
-        expect(@client.custom_member_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_member_and_archieve' do
+          expect(@client.custom_member_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
     end
 
     describe '#custom_member_my' do
       it "returns a custom individual report group by member" do
+        VCR.use_cassette 'custom/custom_my_member' do
         expect(@client.custom_member_my("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        end
       end
 
       it "returns a custom individual report group by member and specific organizations" do
-        expect(@client.custom_member_my("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_member_and_org' do
+          expect(@client.custom_member_my("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by member and specific projects" do
-        expect(@client.custom_member_my("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_member_and_project' do
+          expect(@client.custom_member_my("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by member and specific users" do
-        expect(@client.custom_member_my("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_member_and_user' do
+          expect(@client.custom_member_my("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by member and show tasks" do
-        expect(@client.custom_member_my("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_member_and_task' do
+          expect(@client.custom_member_my("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by member and show notes" do
-        expect(@client.custom_member_my("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_member_and_note' do
+          expect(@client.custom_member_my("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
+      end
+
+      it "returns a custom individual report group by member and show activity" do
+        VCR.use_cassette 'custom/custom_my_member_and_activity' do
+          expect(@client.custom_member_my("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by member and show archieved" do
-        expect(@client.custom_member_my("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
-      end
-
-      it "returns a custom individual report group by member and show tasks" do
-        expect(@client.custom_member_my("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_member_and_archieve' do
+          expect(@client.custom_member_my("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
     end
 
     describe '#custom_project_team' do
       it "returns a custom team report group by project" do
-        expect(@client.custom_project_team("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        VCR.use_cassette 'custom/custom_team_project' do
+          expect(@client.custom_project_team("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        end
       end
 
       it "returns a custom team report group by project and specific organizations" do
-        expect(@client.custom_project_team("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_project_and_org' do
+          expect(@client.custom_project_team("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by project and specific projects" do
-        expect(@client.custom_project_team("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_project_and_project' do
+          expect(@client.custom_project_team("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by project and specific users" do
-        expect(@client.custom_project_team("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_project_and_user' do
+          expect(@client.custom_project_team("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by project and show tasks" do
-        expect(@client.custom_project_team("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_project_and_task' do
+          expect(@client.custom_project_team("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by project and show notes" do
-        expect(@client.custom_project_team("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_project_and_note' do
+          expect(@client.custom_project_team("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
+      end
+
+      it "returns a custom team report group by project and show activity" do
+        VCR.use_cassette 'custom/custom_team_project_and_activity' do
+          expect(@client.custom_project_team("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom team report group by project and show archieved" do
-        expect(@client.custom_project_team("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
-      end
-
-      it "returns a custom team report group by project and show tasks" do
-        expect(@client.custom_project_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_team_project_and_archieve' do
+          expect(@client.custom_project_team("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
     end
 
     describe '#custom_project_my' do
       it "returns a custom individual report group by project" do
-        expect(@client.custom_project_my("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        VCR.use_cassette 'custom/custom_my_project' do
+          expect(@client.custom_project_my("2016-05-23", "2016-05-25")["organizations"]).to be_an_instance_of(Array)
+        end
       end
 
       it "returns a custom individual report group by project and specific organizations" do
-        expect(@client.custom_project_my("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_project_and_org' do
+          expect(@client.custom_project_my("2016-05-23", "2016-05-25", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by project and specific projects" do
-        expect(@client.custom_project_my("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_project_and_project' do
+          expect(@client.custom_project_my("2016-05-23", "2016-05-25", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by project and specific users" do
-        expect(@client.custom_project_my("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_project_and_user' do
+          expect(@client.custom_project_my("2016-05-23", "2016-05-25", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by project and show tasks" do
-        expect(@client.custom_project_my("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_project_and_task' do
+          expect(@client.custom_project_my("2016-05-23", "2016-05-25", show_tasks: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by project and show notes" do
-        expect(@client.custom_project_my("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_project_and_note' do
+          expect(@client.custom_project_my("2016-05-23", "2016-05-25", show_notes: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
+      end
+
+      it "returns a custom individual report group by project and show activity" do
+        VCR.use_cassette 'custom/custom_my_project_and_activity' do
+          expect(@client.custom_project_my("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a custom individual report group by project and show archieved" do
-        expect(@client.custom_project_my("2016-05-23", "2016-05-25", show_activities: true)["organizations"][0]["name"]).to eq("Hook Engine")
-      end
-
-      it "returns a custom individual report group by project and show tasks" do
-        expect(@client.custom_project_my("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'custom/custom_my_project_and_archieve' do
+          expect(@client.custom_project_my("2016-05-23", "2016-05-25", include_archived: true)["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
     end
 

--- a/spec/hubstaff/modules/notes_module_spec.rb
+++ b/spec/hubstaff/modules/notes_module_spec.rb
@@ -3,34 +3,47 @@ require 'spec_helper'
 class Hubstaff::Client
   describe Note do
     before(:each) do
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
+      @client.auth_token = ENV['AUTH_TOKEN']
     end
 
     describe '#notes' do
       it "returns a collection of notes" do
-        expect(@client.notes("2016-05-23", "2016-05-25")['notes']).to be_an_instance_of(Array)
+        VCR.use_cassette 'note/notes' do
+          expect(@client.notes("2016-05-23", "2016-05-25")['notes']).to be_an_instance_of(Array)
+        end
       end
 
       it "returns a collection of notes for a specific organization" do
-        expect(@client.notes("2016-05-23", "2016-05-25", orgs: "27572")["notes"][0]["description"]).to eq("Practice Notes")
+        VCR.use_cassette 'note/notes_org' do
+          expect(@client.notes("2016-05-23", "2016-05-25", orgs: "27572")["notes"][0]["description"]).to eq("Practice Notes")
+        end
       end
 
       it "returns a collection of notes for a specific project" do
-        expect(@client.notes("2016-05-23", "2016-05-25", projects: "112761")["notes"][0]["description"]).to eq("Practice Notes")
+        VCR.use_cassette 'note/notes_project' do
+          expect(@client.notes("2016-05-23", "2016-05-25", projects: "112761")["notes"][0]["description"]).to eq("Practice Notes")
+        end
       end
 
       it "returns a collection of notes for a specific user" do
-        expect(@client.notes("2016-05-23", "2016-05-25", users: "61188")["notes"][0]["description"]).to eq("Practice Notes")
+        VCR.use_cassette 'note/notes_user' do
+          expect(@client.notes("2016-05-23", "2016-05-25", users: "61188")["notes"][0]["description"]).to eq("Practice Notes")
+        end
       end
 
       it "returns a collection of notes with a offset" do
-        expect(@client.notes("2016-05-23", "2016-05-25", offset: 0)["notes"][0]["description"]).to eq("Practice Notes")
+        VCR.use_cassette 'note/notes_offset' do
+          expect(@client.notes("2016-05-23", "2016-05-25", offset: 0)["notes"][0]["description"]).to eq("Practice Notes")
+        end
       end
     end
 
     describe '#find_note' do
       it "returns a specific note" do
-        expect(@client.find_note(716530)["note"]["description"]).to eq("Practice Notes")
+        VCR.use_cassette 'note/find_note' do
+          expect(@client.find_note(716530)["note"]["description"]).to eq("Practice Notes")
+        end
       end
     end
 

--- a/spec/hubstaff/modules/orgs_module_spec.rb
+++ b/spec/hubstaff/modules/orgs_module_spec.rb
@@ -3,30 +3,39 @@ require 'spec_helper'
 class Hubstaff::Client
   describe Organization do
     before(:each) do
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
+      @client.auth_token = ENV['AUTH_TOKEN']
     end
 
     describe '#organizations' do
       it "returns a collection of organizations" do
-        expect(@client.organizations['organizations']).to be_an_instance_of(Array)
+        VCR.use_cassette 'org/orgs' do
+          expect(@client.organizations['organizations']).to be_an_instance_of(Array)
+        end
       end
     end
 
     describe '#find_organization' do
       it "returns a specific organization" do
-        expect(@client.find_organization(27572)).to be_an_instance_of(Hash)
+        VCR.use_cassette 'org/find_org' do
+          expect(@client.find_organization(27572)).to be_an_instance_of(Hash)
+        end
       end
     end
 
     describe "find_org_projects" do
       it "returns active projects for a specific organization" do
-        expect(@client.find_org_projects(27572)).to be_an_instance_of(Hash)
+        VCR.use_cassette 'org/find_org_project' do
+          expect(@client.find_org_projects(27572)).to be_an_instance_of(Hash)
+        end
       end
     end
 
     describe "find_org_members" do
       it "returns a collection of users that are members of a specific org" do
-        expect(@client.find_org_members(27572)['users']).to be_an_instance_of(Array)
+        VCR.use_cassette 'org/find_org_members' do
+          expect(@client.find_org_members(27572)['users']).to be_an_instance_of(Array)
+        end
       end
     end
   end

--- a/spec/hubstaff/modules/projects_module_spec.rb
+++ b/spec/hubstaff/modules/projects_module_spec.rb
@@ -3,32 +3,43 @@ require 'spec_helper'
 class Hubstaff::Client
   describe Project do
     before(:each) do
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
+      @client.auth_token = ENV['AUTH_TOKEN']
     end
 
     describe '#projects' do
       it "returns a collection of projects" do
-        expect(@client.projects['projects']).to be_an_instance_of(Array)
+        VCR.use_cassette 'project/projects' do
+          expect(@client.projects['projects']).to be_an_instance_of(Array)
+        end
       end
 
       it "returns only active projects" do
-        expect(@client.projects("active")['projects'][0]['name']).to eq("Build Ruby Gem")
+        VCR.use_cassette 'project/projects_active' do
+          expect(@client.projects("active")['projects'][0]['name']).to eq("Build Ruby Gem")
+        end
       end
 
       it "returns only archieved projects" do
-        expect(@client.projects("archieved")['projects']).to be_an_instance_of(Array)
+        VCR.use_cassette 'project/projects_archieved' do
+          expect(@client.projects("archieved")['projects']).to be_an_instance_of(Array)
+        end
       end
     end
 
     describe '#find_project' do
       it "returns a specific project" do
-        expect(@client.find_project(112761)).to be_an_instance_of(Hash)
+        VCR.use_cassette 'project/find_project' do
+          expect(@client.find_project(112761)).to be_an_instance_of(Hash)
+        end
       end
     end
 
     describe '#find_project_members' do
       it "returns a collection of members for a specific project" do
-        expect(@client.find_project_members(112761)['users']).to be_an_instance_of(Array)
+        VCR.use_cassette 'project/find_project_members' do
+          expect(@client.find_project_members(112761)['users']).to be_an_instance_of(Array)
+        end
       end
     end
   end

--- a/spec/hubstaff/modules/screenshot_module_spec.rb
+++ b/spec/hubstaff/modules/screenshot_module_spec.rb
@@ -3,20 +3,27 @@ require 'spec_helper'
 class Hubstaff::Client
   describe Screenshot do
       before(:each) do
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
+      @client.auth_token = ENV['AUTH_TOKEN']
     end
 
     describe '#screenshots' do
       it "returns a collection of screenshots for a specific organization" do
-        expect(@client.screenshots("2016-05-22", "2016-05-25", orgs: "27572")).to be_an_instance_of(Hash)
+        VCR.use_cassette 'screen/screenshots_org' do
+          expect(@client.screenshots("2016-05-22", "2016-05-25", orgs: "27572")).to be_an_instance_of(Hash)
+        end
       end
 
       it "returns a collection of screenshots for a specific project" do
-        expect(@client.screenshots("2016-05-22", "2016-05-25", projects: "112761")).to be_an_instance_of(Hash)
+        VCR.use_cassette 'screen/screenshots_project' do
+          expect(@client.screenshots("2016-05-22", "2016-05-25", projects: "112761")).to be_an_instance_of(Hash)
+        end
       end
 
       it "returns a collection of screenshots for a specific user" do
-        expect(@client.screenshots("2016-05-22", "2016-05-25", users: "61188")).to be_an_instance_of(Hash)
+        VCR.use_cassette 'screen/screenshots_user' do
+          expect(@client.screenshots("2016-05-22", "2016-05-25", users: "61188")).to be_an_instance_of(Hash)
+        end
       end
     end
   end

--- a/spec/hubstaff/modules/task_module_spec.rb
+++ b/spec/hubstaff/modules/task_module_spec.rb
@@ -3,26 +3,35 @@ require 'spec_helper'
 class Hubstaff::Client
   describe Task do
     before(:each) do
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
+      @client.auth_token = ENV['AUTH_TOKEN']
     end
 
     describe '#tasks' do
       it "returns a collection of tasks" do
-        expect(@client.tasks(projects: "112761")).to be_an_instance_of(Hash)
+        VCR.use_cassette 'task/tasks' do
+          expect(@client.tasks(projects: "112761")).to be_an_instance_of(Hash)
+        end
       end
 
       it "returns a collection of tasks for a specific project" do
-        expect(@client.tasks(projects: "112761")).to be_an_instance_of(Hash)
+        VCR.use_cassette 'task/tasks_project' do
+          expect(@client.tasks(projects: "112761")).to be_an_instance_of(Hash)
+        end
       end
 
       it "returns a collection of tasks with a offset" do
-        expect(@client.tasks(offset: 0)).to be_an_instance_of(Hash)
+        VCR.use_cassette 'task/tasks_offset' do
+          expect(@client.tasks(offset: 0)).to be_an_instance_of(Hash)
+        end
       end
     end
 
     describe '#find_task' do
       it "returns a specific task" do
-        expect(@client.find_task(716530)).to be_an_instance_of(Hash)
+        VCR.use_cassette 'task/find_task' do
+          expect(@client.find_task(716530)).to be_an_instance_of(Hash)
+        end
       end
     end
   end

--- a/spec/hubstaff/modules/user_module_spec.rb
+++ b/spec/hubstaff/modules/user_module_spec.rb
@@ -3,42 +3,57 @@ require 'spec_helper'
 class Hubstaff::Client
   describe User do
     before(:each) do
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
+      @client.auth_token = ENV['AUTH_TOKEN']
     end
 
     describe "#users" do
       it "returns a collection of users" do
-        expect(@client.users['users']).to be_an_instance_of(Array)
+        VCR.use_cassette 'user/users' do
+          expect(@client.users['users']).to be_an_instance_of(Array)
+        end
       end
 
       it "contains the correct data" do
-        expect(@client.users['users'][0]['email']).to eq(ENV['APP_EMAIL'])
+        VCR.use_cassette 'user/users' do
+          expect(@client.users['users'][0]['email']).to eq(ENV['APP_EMAIL'])
+        end
       end
 
       it "returns organizations if org_member is set to true" do
-        expect(@client.users(true, false)['users'][0]['organizations']).to be_an_instance_of(Array)
+        VCR.use_cassette 'user/users_orgs' do
+          expect(@client.users(true, false)['users'][0]['organizations']).to be_an_instance_of(Array)
+        end
       end
 
       it "returns projects if project_member is set to true" do
-        expect(@client.users(false, true)['users'][0]['projects']).to be_an_instance_of(Array)
+        VCR.use_cassette 'user/users_projects' do
+          expect(@client.users(false, true)['users'][0]['projects']).to be_an_instance_of(Array)
+        end
       end
     end
 
     describe "#find_user" do
       it "returns a specific user in a hash" do
-        expect(@client.find_user(61188)).to be_an_instance_of(Hash)
+        VCR.use_cassette 'user/find_user' do
+          expect(@client.find_user(61188)).to be_an_instance_of(Hash)
+        end
       end
     end
 
     describe "#find_user_orgs" do
       it "returns all user orgs in a array" do
-        expect(@client.find_user_orgs(61188)['organizations']).to be_an_instance_of(Array)
+        VCR.use_cassette 'user/find_user_orgs' do
+          expect(@client.find_user_orgs(61188)['organizations']).to be_an_instance_of(Array)
+        end
       end
     end
 
     describe "#find_user_projects" do
       it "returns all user projects in a array" do
-        expect(@client.find_user_projects(61188)['projects']).to be_an_instance_of(Array)
+        VCR.use_cassette 'user/find_user_projects' do
+          expect(@client.find_user_projects(61188)['projects']).to be_an_instance_of(Array)
+        end
       end
     end
   end

--- a/spec/hubstaff/modules/weekly_module_spec.rb
+++ b/spec/hubstaff/modules/weekly_module_spec.rb
@@ -3,51 +3,72 @@ require 'spec_helper'
 class Hubstaff::Client
   describe Weekly do
     before(:each) do
-      @client = Hubstaff::Client.new(ENV['APP_EMAIL'], ENV['APP_PASSWORD'], ENV['AUTH_TOKEN'])
+      @client = Hubstaff::Client.new(ENV['APP_TOKEN'])
+      @client.auth_token = ENV['AUTH_TOKEN']
     end
 
     describe '#weekly_team' do
       it "returns a weekly team report with default settings" do
-        expect(@client.weekly_team["organizations"]).to be_an_instance_of(Array)
+        VCR.use_cassette 'weekly/weekly_team' do
+          expect(@client.weekly_team["organizations"]).to be_an_instance_of(Array)
+        end
       end
 
       it "returns a weekly team report with a specific date in week" do
-        expect(@client.weekly_team(date: "2016-05-24")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'weekly/weekly_team_date' do
+          expect(@client.weekly_team(date: "2016-05-24")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a weekly team report with a specific orgnaization" do
-        expect(@client.weekly_team(date: "2016-05-24", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'weekly/weekly_team_org' do
+          expect(@client.weekly_team(date: "2016-05-24", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a weekly team report with a specific project" do
-        expect(@client.weekly_team(date: "2016-05-24", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'weekly/weekly_team_project' do
+          expect(@client.weekly_team(date: "2016-05-24", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a weekly team report with a specific user" do
-        expect(@client.weekly_team(date: "2016-05-24", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'weekly/weekly_team_user' do
+          expect(@client.weekly_team(date: "2016-05-24", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
- 
+
     end
 
     describe '#weekly_my' do
       it "returns a weekly individual report with default settings" do
-        expect(@client.weekly_my["organizations"]).to be_an_instance_of(Array)
+        VCR.use_cassette 'weekly/weekly_my' do
+          expect(@client.weekly_my["organizations"]).to be_an_instance_of(Array)
+        end
       end
 
       it "returns a weekly individual report with a specific date in week" do
-        expect(@client.weekly_my(date: "2016-05-24")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'weekly/weekly_my_date' do
+          expect(@client.weekly_my(date: "2016-05-24")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a weekly individual report with a specific orgnaization" do
-        expect(@client.weekly_my(date: "2016-05-24", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'weekly/weekly_my_org' do
+          expect(@client.weekly_my(date: "2016-05-24", orgs: "27572")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a weekly individual report with a specific project" do
-        expect(@client.weekly_my(date: "2016-05-24", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'weekly/weekly_my_project' do
+          expect(@client.weekly_my(date: "2016-05-24", projects: "112761")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
 
       it "returns a weekly individual report with a specific user" do
-        expect(@client.weekly_my(date: "2016-05-24", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        VCR.use_cassette 'weekly/weekly_my_user' do
+          expect(@client.weekly_my(date: "2016-05-24", users: "61188")["organizations"][0]["name"]).to eq("Hook Engine")
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'hubstaff'
 require 'dotenv'
+require 'vcr'
+require 'support/vcr_setup.rb'
 Dotenv.load(".env.local")

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -1,0 +1,4 @@
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/vcr'
+  c.hook_into :faraday
+end

--- a/spec/vcr/activity/activites_offset.yml
+++ b/spec/vcr/activity/activites_offset.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/activities?offset=0&start_time=2016-05-24&stop_time=2016-05-24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:06:23 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 3bb506db-c2b4-45ac-9e5a-42fd3a28d8fc
+      etag:
+      - W/"5438bc2ab8e35c0f2f6711e754b43735"
+      x-runtime:
+      - '5.116885'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"activities":[{"id":98613589,"time_slot":"2016-05-24T00:00:00Z","starts_at":"2016-05-24T00:00:00Z","user_id":61188,"project_id":112761,"keyboard":0,"mouse":0,"overall":0,"tracked":600,"paid":false}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:06:23 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/activity/activites_user.yml
+++ b/spec/vcr/activity/activites_user.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/activities?start_time=2016-05-24&stop_time=2016-05-24&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 18:54:01 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 14d88d80-d3a1-4337-bde3-6d1c78cd4e5d
+      etag:
+      - W/"5438bc2ab8e35c0f2f6711e754b43735"
+      x-runtime:
+      - '0.056477'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"activities":[{"id":98613589,"time_slot":"2016-05-24T00:00:00Z","starts_at":"2016-05-24T00:00:00Z","user_id":61188,"project_id":112761,"keyboard":0,"mouse":0,"overall":0,"tracked":600,"paid":false}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:54:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/activity/activities.yml
+++ b/spec/vcr/activity/activities.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/activities?start_time=2016-05-24&stop_time=2016-05-24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:06:17 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 22f9aecf-38df-4168-8312-8a6119beef90
+      etag:
+      - W/"5438bc2ab8e35c0f2f6711e754b43735"
+      x-runtime:
+      - '5.404047'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"activities":[{"id":98613589,"time_slot":"2016-05-24T00:00:00Z","starts_at":"2016-05-24T00:00:00Z","user_id":61188,"project_id":112761,"keyboard":0,"mouse":0,"overall":0,"tracked":600,"paid":false}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:06:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/activity/activities_org.yml
+++ b/spec/vcr/activity/activities_org.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/activities?organizations=27572&start_time=2016-05-24&stop_time=2016-05-24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 18:53:30 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 19c56f00-688c-4eb2-b492-9c4a1e1fe072
+      etag:
+      - W/"5438bc2ab8e35c0f2f6711e754b43735"
+      x-runtime:
+      - '0.069558'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"activities":[{"id":98613589,"time_slot":"2016-05-24T00:00:00Z","starts_at":"2016-05-24T00:00:00Z","user_id":61188,"project_id":112761,"keyboard":0,"mouse":0,"overall":0,"tracked":600,"paid":false}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:53:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/activity/activities_project.yml
+++ b/spec/vcr/activity/activities_project.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/activities?projects=112761&start_time=2016-05-24&stop_time=2016-05-24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 18:53:30 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - bd174f1c-ab57-4be4-931a-936d930c87a5
+      etag:
+      - W/"5438bc2ab8e35c0f2f6711e754b43735"
+      x-runtime:
+      - '0.056335'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"activities":[{"id":98613589,"time_slot":"2016-05-24T00:00:00Z","starts_at":"2016-05-24T00:00:00Z","user_id":61188,"project_id":112761,"keyboard":0,"mouse":0,"overall":0,"tracked":600,"paid":false}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:53:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/api/client.yml
+++ b/spec/vcr/api/client.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hubstaff.com/v1/auth?email=rkcudjoe%40hookengine.com&password=hookdev001
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '143'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 14:04:41 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 933e5b6e-c0de-4674-9eef-d82d2f5b3b3c
+      etag:
+      - W/"4e97488ea5a33bb7d4700432f9da12df"
+      x-runtime:
+      - '0.404189'
+      x-rack-cache:
+      - invalidate, pass
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"user":{"id":61188,"name":"Raymond Cudjoe","last_activity":"2016-05-24T01:25:21Z","auth_token":"5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U"}}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 14:04:44 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_my_date.yml
+++ b/spec/vcr/custom/custom_data_my_date.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/my?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      x-rack-cache:
+      - miss
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:13 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.039641'
+      x-request-id:
+      - 7e13be22-fd35-4a59-a732-d7256760e167
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_my_date_and_activity.yml
+++ b/spec/vcr/custom/custom_data_my_date_and_activity.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/my?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:11 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 9f5da26a-e354-4734-a765-e3fbaba1538f
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.072763'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_my_date_and_archieve.yml
+++ b/spec/vcr/custom/custom_data_my_date_and_archieve.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/my?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:15 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 96f3d179-f249-4eac-bc9b-9c5367ea814b
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.132871'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_my_date_and_note.yml
+++ b/spec/vcr/custom/custom_data_my_date_and_note.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/my?end_date=2016-05-25&show_notes=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:14 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 566b31b0-69e6-476a-ac0e-d3df8657bc9e
+      etag:
+      - W/"336fce3e184feb4fb6b1f0887e3425a5"
+      x-runtime:
+      - '0.056032'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874,"notes":[{"id":716530,"description":"Practice
+        Notes"}]}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:14 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_my_date_and_orgs.yml
+++ b/spec/vcr/custom/custom_data_my_date_and_orgs.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/my?end_date=2016-05-25&organizations=27572&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:14 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 1e419906-49d4-4413-93de-4bc1009ec617
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.038780'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:14 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_my_date_and_projects.yml
+++ b/spec/vcr/custom/custom_data_my_date_and_projects.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/my?end_date=2016-05-25&projects=112761&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:11 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - e75abdf8-c951-44b5-9231-cb5545890ac6
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.154396'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_my_date_and_task.yml
+++ b/spec/vcr/custom/custom_data_my_date_and_task.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/my?end_date=2016-05-25&show_tasks=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:12 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 66e8c0c6-df8f-480b-b22c-566f60b5e39f
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.075728'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_my_date_and_user.yml
+++ b/spec/vcr/custom/custom_data_my_date_and_user.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/my?end_date=2016-05-25&start_date=2016-05-23&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:13 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 7be549d1-8453-4e8c-9ffc-19dc5426e693
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.052465'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_team_date.yml
+++ b/spec/vcr/custom/custom_data_team_date.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/team?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:16 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 537d55e2-20bd-479a-b19d-d17345be63b6
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.048838'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_team_date_and_activity.yml
+++ b/spec/vcr/custom/custom_data_team_date_and_activity.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/team?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:18 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 6c5b5982-10cb-49cd-a043-982c220636e3
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.046304'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_team_date_and_archieve.yml
+++ b/spec/vcr/custom/custom_data_team_date_and_archieve.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/team?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:16 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - bddf164c-0c22-43dd-836d-4a9f554cbb8b
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.056286'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:16 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_team_date_and_note.yml
+++ b/spec/vcr/custom/custom_data_team_date_and_note.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/team?end_date=2016-05-25&show_notes=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:15 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - ed7f733b-0acd-438d-b114-4391a7c53844
+      etag:
+      - W/"336fce3e184feb4fb6b1f0887e3425a5"
+      x-runtime:
+      - '0.105403'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874,"notes":[{"id":716530,"description":"Practice
+        Notes"}]}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_team_date_and_org.yml
+++ b/spec/vcr/custom/custom_data_team_date_and_org.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/team?end_date=2016-05-25&organizations=27572&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      x-rack-cache:
+      - miss
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:18 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.045925'
+      x-request-id:
+      - 275994c8-be15-4e56-85e5-0ee8f15dfaed
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_team_date_and_project.yml
+++ b/spec/vcr/custom/custom_data_team_date_and_project.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/team?end_date=2016-05-25&projects=112761&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:17 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 3e47141e-3590-4fa4-8489-1dd92d2dc778
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.066588'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_team_date_and_task.yml
+++ b/spec/vcr/custom/custom_data_team_date_and_task.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/team?end_date=2016-05-25&show_tasks=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:17 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - a2d9c24c-c3ad-4be6-be08-9ae22c751d77
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.043761'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_data_team_date_and_user.yml
+++ b/spec/vcr/custom/custom_data_team_date_and_user.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_date/team?end_date=2016-05-25&start_date=2016-05-23&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:19 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - c4fda73c-10f1-4f2e-ac45-26138f1a9a83
+      etag:
+      - W/"a7613413932a22c48b8c32a4281de156"
+      x-runtime:
+      - '0.099474'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"projects":[{"id":112761,"name":"Build Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_member.yml
+++ b/spec/vcr/custom/custom_my_member.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/my?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:05 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 22558e3a-1a65-4e3e-a169-a95a0a4013f6
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.047927'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_member_and_activity.yml
+++ b/spec/vcr/custom/custom_my_member_and_activity.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/my?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:02 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 67a80b77-d073-40cc-be96-6b98c9560eae
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.051110'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_member_and_archieve.yml
+++ b/spec/vcr/custom/custom_my_member_and_archieve.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/my?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:06 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 61c24e4e-b22f-4a34-a094-17874b1fec24
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.041325'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_member_and_note.yml
+++ b/spec/vcr/custom/custom_my_member_and_note.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/my?end_date=2016-05-25&show_notes=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:04 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 55eb48ab-c151-4070-a484-c902e27ad821
+      etag:
+      - W/"04ec4da7d258db350080ed9ba4a5b5e4"
+      x-runtime:
+      - '0.082498'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"notes":[{"id":716530,"description":"Practice Notes"}]}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_member_and_org.yml
+++ b/spec/vcr/custom/custom_my_member_and_org.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/my?end_date=2016-05-25&organizations=27572&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:05 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 9e030ed4-fe7c-48c0-a45d-010ac1e08662
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.044316'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_member_and_project.yml
+++ b/spec/vcr/custom/custom_my_member_and_project.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/my?end_date=2016-05-25&projects=112761&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:03 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 823c20bd-cc39-413a-8625-b115f2ebfdd8
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.080020'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_member_and_task.yml
+++ b/spec/vcr/custom/custom_my_member_and_task.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/my?end_date=2016-05-25&show_tasks=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:04 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - f51c21b2-f528-496c-80c4-9603d354d0c5
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.047026'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_member_and_user.yml
+++ b/spec/vcr/custom/custom_my_member_and_user.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/my?end_date=2016-05-25&start_date=2016-05-23&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:03 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 74341750-3f8e-442a-aa32-e4491269e209
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.042315'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_project.yml
+++ b/spec/vcr/custom/custom_my_project.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/my?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:07 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 6c9cd910-0b99-465f-bfac-8c10bb551b63
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.038159'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_project_and_activity.yml
+++ b/spec/vcr/custom/custom_my_project_and_activity.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/my?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:10 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 913ed54e-d161-4c32-89ef-3442157133a6
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.303919'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_project_and_archieve.yml
+++ b/spec/vcr/custom/custom_my_project_and_archieve.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/my?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:08 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 5e5372f1-601c-41c8-b5a3-1b5ae10fa718
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.072722'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_project_and_note.yml
+++ b/spec/vcr/custom/custom_my_project_and_note.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/my?end_date=2016-05-25&show_notes=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:09 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 13f505f4-3787-494a-9932-5552e9850b29
+      etag:
+      - W/"2c1b8a6db5b665a6b9c8a883ea81bed5"
+      x-runtime:
+      - '0.054373'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"notes":[{"id":716530,"description":"Practice Notes"}]}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_project_and_org.yml
+++ b/spec/vcr/custom/custom_my_project_and_org.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/my?end_date=2016-05-25&organizations=27572&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:09 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 749c95e1-d084-40c2-b2df-f0e9f5a67968
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.082913'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_project_and_project.yml
+++ b/spec/vcr/custom/custom_my_project_and_project.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/my?end_date=2016-05-25&projects=112761&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:07 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 8bbcb3dc-af65-4cff-8222-18d4e2db2987
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.053968'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_project_and_task.yml
+++ b/spec/vcr/custom/custom_my_project_and_task.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/my?end_date=2016-05-25&show_tasks=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:08 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 61b98429-b45a-4023-b59c-a64770d9a64e
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.064660'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_my_project_and_user.yml
+++ b/spec/vcr/custom/custom_my_project_and_user.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/my?end_date=2016-05-25&start_date=2016-05-23&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:06 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 9a1423b1-3760-4b04-9b01-540eeadce6e4
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.040450'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_member.yml
+++ b/spec/vcr/custom/custom_team_member.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/team?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:57 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 5bd90638-fc07-45d4-8746-cdc91d4c9a41
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.040622'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_member_and_activity.yml
+++ b/spec/vcr/custom/custom_team_member_and_activity.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/team?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:54 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - e62e08a4-fef2-49dc-9c8d-88ff39be8c94
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.199388'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_member_and_archieve.yml
+++ b/spec/vcr/custom/custom_team_member_and_archieve.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/team?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:56 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 9e5b44a7-bf8a-4957-b626-f6a0d0b12d50
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '1.245537'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_member_and_note.yml
+++ b/spec/vcr/custom/custom_team_member_and_note.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/team?end_date=2016-05-25&show_notes=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:52 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 3eb16921-ece3-4afa-91d7-ebd74d136828
+      etag:
+      - W/"04ec4da7d258db350080ed9ba4a5b5e4"
+      x-runtime:
+      - '1.335076'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"notes":[{"id":716530,"description":"Practice Notes"}]}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_member_and_org.yml
+++ b/spec/vcr/custom/custom_team_member_and_org.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/team?end_date=2016-05-25&organizations=27572&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:57 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - dec45edd-292e-4982-a1e8-58ee127b4c0c
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.043999'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_member_and_project.yml
+++ b/spec/vcr/custom/custom_team_member_and_project.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/team?end_date=2016-05-25&projects=112761&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:52 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 49cb8545-03b6-4586-9818-039c92cc6d78
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.040119'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_member_and_task.yml
+++ b/spec/vcr/custom/custom_team_member_and_task.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/team?end_date=2016-05-25&show_tasks=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:53 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - cb02525e-722d-4933-be6c-76a5645245a8
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.360336'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_member_and_user.yml
+++ b/spec/vcr/custom/custom_team_member_and_user.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_member/team?end_date=2016-05-25&start_date=2016-05-23&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:54 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 1c6fb414-58c5-49f3-834b-83f40c1ce94e
+      etag:
+      - W/"eb90f3250206e53d848a8ddb57efd693"
+      x-runtime:
+      - '0.058040'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_project.yml
+++ b/spec/vcr/custom/custom_team_project.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/team?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:00 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 5d9cb988-03a7-4719-8520-c1bd5c6b2a98
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.137947'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_project_and_activity.yml
+++ b/spec/vcr/custom/custom_team_project_and_activity.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/team?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:58 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 6cde7a7d-61aa-4adf-9573-b2e799e21bc1
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.084608'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_project_and_archieve.yml
+++ b/spec/vcr/custom/custom_team_project_and_archieve.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/team?end_date=2016-05-25&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      x-rack-cache:
+      - miss
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:00 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.041616'
+      x-request-id:
+      - 8781eba4-9184-482c-93a2-268422051233
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_project_and_note.yml
+++ b/spec/vcr/custom/custom_team_project_and_note.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/team?end_date=2016-05-25&show_notes=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:58 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 9327b48f-676c-423c-9e47-13e63f3ba34b
+      etag:
+      - W/"2c1b8a6db5b665a6b9c8a883ea81bed5"
+      x-runtime:
+      - '0.160167'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"notes":[{"id":716530,"description":"Practice Notes"}]}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_project_and_org.yml
+++ b/spec/vcr/custom/custom_team_project_and_org.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/team?end_date=2016-05-25&organizations=27572&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:02 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - fadad915-6e73-456b-b024-6919ab2df286
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.209749'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_project_and_project.yml
+++ b/spec/vcr/custom/custom_team_project_and_project.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/team?end_date=2016-05-25&projects=112761&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:45:01 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 1017fb79-d2ce-44c1-95a0-927540dada7f
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.042885'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:45:01 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_project_and_task.yml
+++ b/spec/vcr/custom/custom_team_project_and_task.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/team?end_date=2016-05-25&show_tasks=true&start_date=2016-05-23
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:59 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 14fc3640-9309-4e3b-8c95-f4b4f8d9d38f
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.048047'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/custom/custom_team_project_and_user.yml
+++ b/spec/vcr/custom/custom_team_project_and_user.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/custom/by_project/team?end_date=2016-05-25&start_date=2016-05-23&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 19:44:59 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - c18b45b5-96d9-41c9-a2ea-a3981ab45ea3
+      etag:
+      - W/"32a3af3ead945c75a392c5267386b441"
+      x-runtime:
+      - '0.041690'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"projects":[{"id":112761,"name":"Build
+        Ruby Gem","duration":7874,"dates":[{"date":"2016-05-23","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874}]}]}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 19:44:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/note/find_note.yml
+++ b/spec/vcr/note/find_note.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/notes/716530
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:15:37 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 4c82367f-9b89-4135-8057-c36ce0f1396f
+      etag:
+      - W/"57d2d09ca2ac08ebe955a9694baa5fbc"
+      x-runtime:
+      - '0.125087'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"note":{"id":716530,"description":"Practice Notes","time_slot":"2016-05-23T22:20:00Z","recorded_at":"2016-06-04T19:08:22Z","user_id":61188,"project_id":112761}}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:15:37 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/note/notes.yml
+++ b/spec/vcr/note/notes.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/notes?start_time=2016-05-23&stop_time=2016-05-25
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:15:39 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - fa8aae52-68b2-4f2c-8d79-e26c6a231aa8
+      etag:
+      - W/"0261e46d499a3d25147275d7cfb8c27b"
+      x-runtime:
+      - '1.842545'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"notes":[{"id":716530,"description":"Practice Notes","time_slot":"2016-05-23T22:20:00Z","recorded_at":"2016-06-04T19:08:22Z","user_id":61188,"project_id":112761}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:15:39 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/note/notes_offset.yml
+++ b/spec/vcr/note/notes_offset.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/notes?offset=0&start_time=2016-05-23&stop_time=2016-05-25
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:15:41 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - c8ecd95f-f024-4794-a081-3f52c449e25f
+      etag:
+      - W/"0261e46d499a3d25147275d7cfb8c27b"
+      x-runtime:
+      - '0.212458'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"notes":[{"id":716530,"description":"Practice Notes","time_slot":"2016-05-23T22:20:00Z","recorded_at":"2016-06-04T19:08:22Z","user_id":61188,"project_id":112761}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:15:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/note/notes_org.yml
+++ b/spec/vcr/note/notes_org.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/notes?organizations=27572&start_time=2016-05-23&stop_time=2016-05-25
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:15:42 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 2b939e2b-432b-45db-a56d-88ee5a7c28a9
+      etag:
+      - W/"0261e46d499a3d25147275d7cfb8c27b"
+      x-runtime:
+      - '0.031583'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"notes":[{"id":716530,"description":"Practice Notes","time_slot":"2016-05-23T22:20:00Z","recorded_at":"2016-06-04T19:08:22Z","user_id":61188,"project_id":112761}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:15:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/note/notes_project.yml
+++ b/spec/vcr/note/notes_project.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/notes?projects=112761&start_time=2016-05-23&stop_time=2016-05-25
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:15:41 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 07d82862-f83b-4efb-8e12-7053cd9aaa4a
+      etag:
+      - W/"0261e46d499a3d25147275d7cfb8c27b"
+      x-runtime:
+      - '0.034217'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"notes":[{"id":716530,"description":"Practice Notes","time_slot":"2016-05-23T22:20:00Z","recorded_at":"2016-06-04T19:08:22Z","user_id":61188,"project_id":112761}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:15:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/note/notes_user.yml
+++ b/spec/vcr/note/notes_user.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/notes?start_time=2016-05-23&stop_time=2016-05-25&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:15:40 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 5ee40620-68b2-4774-acfc-b603942b61e8
+      etag:
+      - W/"0261e46d499a3d25147275d7cfb8c27b"
+      x-runtime:
+      - '0.078750'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"notes":[{"id":716530,"description":"Practice Notes","time_slot":"2016-05-23T22:20:00Z","recorded_at":"2016-06-04T19:08:22Z","user_id":61188,"project_id":112761}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:15:40 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/org/find_org.yml
+++ b/spec/vcr/org/find_org.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/organizations/27572
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '89'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:17:57 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 7fd7b667-2f91-4cfb-94c6-eae2f593ba56
+      etag:
+      - W/"a03c94a434ba40599fc5223ddc70e2c4"
+      x-runtime:
+      - '0.038142'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"organization":{"id":27572,"name":"Hook Engine","last_activity":"2016-05-24T01:25:21Z"}}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:17:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/org/find_org_members.yml
+++ b/spec/vcr/org/find_org_members.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/organizations/27572/members?offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '146'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:17:57 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 547d735e-e958-4107-8c0c-58445656e51c
+      etag:
+      - W/"7846c3a31086e61908f175f77bed7b72"
+      x-runtime:
+      - '0.089544'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"users":[{"id":61188,"name":"Raymond Cudjoe","last_activity":"2016-05-24T01:25:21Z","email":"rkcudjoe@hookengine.com","pay_rate":"No
+        rate set"}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:17:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/org/find_org_project.yml
+++ b/spec/vcr/org/find_org_project.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/organizations/27572/projects?offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:18:22 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 459ca82b-7d17-4952-8a08-444dbc3ae8e7
+      etag:
+      - W/"b49d2caa1abe08f1c56c8ebbfc82f346"
+      x-runtime:
+      - '0.037217'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"projects":[{"id":112761,"name":"Build Ruby Gem","last_activity":"2016-05-24T01:25:21Z","status":"Active","description":null},{"id":120320,"name":"Hubstaff
+        API tutorial","last_activity":null,"status":"Active","description":null}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:18:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/org/orgs.yml
+++ b/spec/vcr/org/orgs.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/organizations?offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '92'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:17:58 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 0a46e05b-5e02-4d6c-a2ef-d8e02a55ee2c
+      etag:
+      - W/"7bd7378ce220cf2765d17e49f0b1d957"
+      x-runtime:
+      - '0.039723'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","last_activity":"2016-05-24T01:25:21Z"}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:17:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/project/find_project.yml
+++ b/spec/vcr/project/find_project.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/projects/112761
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '125'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:20:45 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 071952e7-fe3d-4d77-ad5c-1065744db7e8
+      etag:
+      - W/"76032a1406a1f3bacd1882d8751f1cf8"
+      x-runtime:
+      - '0.065843'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"project":{"id":112761,"name":"Build Ruby Gem","last_activity":"2016-05-24T01:25:21Z","status":"Active","description":null}}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:20:45 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/project/find_project_members.yml
+++ b/spec/vcr/project/find_project_members.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/projects/112761/members?offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '121'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:20:41 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - f8c1d8ff-c0f4-48ab-8be1-03b9b56d9863
+      etag:
+      - W/"1603f05314cc5decff4b89e0fec0315b"
+      x-runtime:
+      - '0.054638'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"users":[{"id":61188,"name":"Raymond Cudjoe","last_activity":"2016-05-24T01:25:21Z","email":"rkcudjoe@hookengine.com"}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:20:41 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/project/projects.yml
+++ b/spec/vcr/project/projects.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/projects?offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:20:52 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - f970ee8c-dad8-46d4-82c7-5e78a3433300
+      etag:
+      - W/"b49d2caa1abe08f1c56c8ebbfc82f346"
+      x-runtime:
+      - '0.114182'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"projects":[{"id":112761,"name":"Build Ruby Gem","last_activity":"2016-05-24T01:25:21Z","status":"Active","description":null},{"id":120320,"name":"Hubstaff
+        API tutorial","last_activity":null,"status":"Active","description":null}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:20:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/project/projects_active.yml
+++ b/spec/vcr/project/projects_active.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/projects?offset=0&status=active
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:20:51 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 93e75df6-522f-4e1a-bd31-68b54aee3917
+      etag:
+      - W/"b49d2caa1abe08f1c56c8ebbfc82f346"
+      x-runtime:
+      - '0.083795'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"projects":[{"id":112761,"name":"Build Ruby Gem","last_activity":"2016-05-24T01:25:21Z","status":"Active","description":null},{"id":120320,"name":"Hubstaff
+        API tutorial","last_activity":null,"status":"Active","description":null}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:20:51 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/project/projects_archieved.yml
+++ b/spec/vcr/project/projects_archieved.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/projects?offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:20:50 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 15ae214a-63cc-4834-9d8d-b695c98bc1e8
+      etag:
+      - W/"b49d2caa1abe08f1c56c8ebbfc82f346"
+      x-runtime:
+      - '0.088202'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"projects":[{"id":112761,"name":"Build Ruby Gem","last_activity":"2016-05-24T01:25:21Z","status":"Active","description":null},{"id":120320,"name":"Hubstaff
+        API tutorial","last_activity":null,"status":"Active","description":null}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:20:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/screen/screenshots_org.yml
+++ b/spec/vcr/screen/screenshots_org.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/screenshots?organizations=27572&start_time=2016-05-22&stop_time=2016-05-25
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:28:08 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 5c0f225a-3ec1-4ba3-a7d2-27516bea5c77
+      etag:
+      - W/"740139bf4f45413f384a010533ada4da"
+      x-runtime:
+      - '0.054834'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"screenshots":[{"id":173200938,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/c0ee59a20ef67f9537057e50fcd2132f515cc45e/0.jpg","time_slot":"2016-05-23T22:00:00Z","recorded_at":"2016-05-23T22:08:36Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173200946,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/07411361cb290b3b6f1990ae543f2d8b4e1eb463/0.jpg","time_slot":"2016-05-23T22:10:00Z","recorded_at":"2016-05-23T22:11:15Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173202151,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/3012270d9192734d93d861ed0eb9de66d68721ca/0.jpg","time_slot":"2016-05-23T22:20:00Z","recorded_at":"2016-05-23T22:23:05Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173209073,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/5f482abab2d06ec9d21837bb064e2407ba86cb4a/0.jpg","time_slot":"2016-05-23T22:30:00Z","recorded_at":"2016-05-23T22:38:57Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173209082,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/fe8468512d27fb73f5b11224f8319901831e7243/0.jpg","time_slot":"2016-05-23T22:40:00Z","recorded_at":"2016-05-23T22:48:26Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173212560,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/cd51a2a8b0f381ee0cf535a807f3de3a7b9aae6a/0.jpg","time_slot":"2016-05-23T22:50:00Z","recorded_at":"2016-05-23T22:52:03Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173214487,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/ec4ad9d53abdc6ef0415f9b7f120234100e5c95b/0.jpg","time_slot":"2016-05-23T23:00:00Z","recorded_at":"2016-05-23T23:05:51Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173218383,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/aa8435d4e083915b96d4813dc969554b3ba8cec5/0.jpg","time_slot":"2016-05-23T23:10:00Z","recorded_at":"2016-05-23T23:12:51Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173218389,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/4a794505873b26e068256ddcb99b80be50cf152c/0.jpg","time_slot":"2016-05-23T23:20:00Z","recorded_at":"2016-05-23T23:20:54Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173222901,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/2419fd9aad3293a1322b45c8671caa471cf8f931/0.jpg","time_slot":"2016-05-23T23:30:00Z","recorded_at":"2016-05-23T23:35:04Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173225033,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/fad4d39d397276fac908a80fe56cc08453adcf9b/0.jpg","time_slot":"2016-05-23T23:40:00Z","recorded_at":"2016-05-23T23:42:35Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173227360,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/617337f02ca3bf3e7cf14b4fef6e75d7c6356d79/0.jpg","time_slot":"2016-05-23T23:50:00Z","recorded_at":"2016-05-23T23:51:45Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173233089,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/9c78aee48c75b8441a4d6fcfde11b4a92631df11/0.jpg","time_slot":"2016-05-24T00:00:00Z","recorded_at":"2016-05-24T00:05:03Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173233095,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/b49ef1b5b9fb33f1835c2a165c422059705bc5a9/0.jpg","time_slot":"2016-05-24T00:10:00Z","recorded_at":"2016-05-24T00:19:11Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173236951,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/bf60b31559277b2139fdb7949c14f598af35adcf/0.jpg","time_slot":"2016-05-24T00:20:00Z","recorded_at":"2016-05-24T00:28:51Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173236957,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/e89877b6237e22e5dd54dd2eaf2e752290c775b7/0.jpg","time_slot":"2016-05-24T00:30:00Z","recorded_at":"2016-05-24T00:37:09Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:28:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/screen/screenshots_project.yml
+++ b/spec/vcr/screen/screenshots_project.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/screenshots?projects=112761&start_time=2016-05-22&stop_time=2016-05-25
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:27:07 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 3c629be6-91f8-4ed7-9e74-5e966bc1073e
+      etag:
+      - W/"740139bf4f45413f384a010533ada4da"
+      x-runtime:
+      - '0.085476'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"screenshots":[{"id":173200938,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/c0ee59a20ef67f9537057e50fcd2132f515cc45e/0.jpg","time_slot":"2016-05-23T22:00:00Z","recorded_at":"2016-05-23T22:08:36Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173200946,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/07411361cb290b3b6f1990ae543f2d8b4e1eb463/0.jpg","time_slot":"2016-05-23T22:10:00Z","recorded_at":"2016-05-23T22:11:15Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173202151,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/3012270d9192734d93d861ed0eb9de66d68721ca/0.jpg","time_slot":"2016-05-23T22:20:00Z","recorded_at":"2016-05-23T22:23:05Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173209073,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/5f482abab2d06ec9d21837bb064e2407ba86cb4a/0.jpg","time_slot":"2016-05-23T22:30:00Z","recorded_at":"2016-05-23T22:38:57Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173209082,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/fe8468512d27fb73f5b11224f8319901831e7243/0.jpg","time_slot":"2016-05-23T22:40:00Z","recorded_at":"2016-05-23T22:48:26Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173212560,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/cd51a2a8b0f381ee0cf535a807f3de3a7b9aae6a/0.jpg","time_slot":"2016-05-23T22:50:00Z","recorded_at":"2016-05-23T22:52:03Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173214487,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/ec4ad9d53abdc6ef0415f9b7f120234100e5c95b/0.jpg","time_slot":"2016-05-23T23:00:00Z","recorded_at":"2016-05-23T23:05:51Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173218383,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/aa8435d4e083915b96d4813dc969554b3ba8cec5/0.jpg","time_slot":"2016-05-23T23:10:00Z","recorded_at":"2016-05-23T23:12:51Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173218389,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/4a794505873b26e068256ddcb99b80be50cf152c/0.jpg","time_slot":"2016-05-23T23:20:00Z","recorded_at":"2016-05-23T23:20:54Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173222901,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/2419fd9aad3293a1322b45c8671caa471cf8f931/0.jpg","time_slot":"2016-05-23T23:30:00Z","recorded_at":"2016-05-23T23:35:04Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173225033,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/fad4d39d397276fac908a80fe56cc08453adcf9b/0.jpg","time_slot":"2016-05-23T23:40:00Z","recorded_at":"2016-05-23T23:42:35Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173227360,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/617337f02ca3bf3e7cf14b4fef6e75d7c6356d79/0.jpg","time_slot":"2016-05-23T23:50:00Z","recorded_at":"2016-05-23T23:51:45Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173233089,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/9c78aee48c75b8441a4d6fcfde11b4a92631df11/0.jpg","time_slot":"2016-05-24T00:00:00Z","recorded_at":"2016-05-24T00:05:03Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173233095,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/b49ef1b5b9fb33f1835c2a165c422059705bc5a9/0.jpg","time_slot":"2016-05-24T00:10:00Z","recorded_at":"2016-05-24T00:19:11Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173236951,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/bf60b31559277b2139fdb7949c14f598af35adcf/0.jpg","time_slot":"2016-05-24T00:20:00Z","recorded_at":"2016-05-24T00:28:51Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173236957,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/e89877b6237e22e5dd54dd2eaf2e752290c775b7/0.jpg","time_slot":"2016-05-24T00:30:00Z","recorded_at":"2016-05-24T00:37:09Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:27:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/screen/screenshots_user.yml
+++ b/spec/vcr/screen/screenshots_user.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/screenshots?start_time=2016-05-22&stop_time=2016-05-25&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 20:27:08 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 26d6e14a-3db9-477c-90d1-779638489295
+      etag:
+      - W/"740139bf4f45413f384a010533ada4da"
+      x-runtime:
+      - '0.058946'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"screenshots":[{"id":173200938,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/c0ee59a20ef67f9537057e50fcd2132f515cc45e/0.jpg","time_slot":"2016-05-23T22:00:00Z","recorded_at":"2016-05-23T22:08:36Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173200946,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/07411361cb290b3b6f1990ae543f2d8b4e1eb463/0.jpg","time_slot":"2016-05-23T22:10:00Z","recorded_at":"2016-05-23T22:11:15Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173202151,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/3012270d9192734d93d861ed0eb9de66d68721ca/0.jpg","time_slot":"2016-05-23T22:20:00Z","recorded_at":"2016-05-23T22:23:05Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173209073,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/5f482abab2d06ec9d21837bb064e2407ba86cb4a/0.jpg","time_slot":"2016-05-23T22:30:00Z","recorded_at":"2016-05-23T22:38:57Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173209082,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/fe8468512d27fb73f5b11224f8319901831e7243/0.jpg","time_slot":"2016-05-23T22:40:00Z","recorded_at":"2016-05-23T22:48:26Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173212560,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/cd51a2a8b0f381ee0cf535a807f3de3a7b9aae6a/0.jpg","time_slot":"2016-05-23T22:50:00Z","recorded_at":"2016-05-23T22:52:03Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173214487,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/ec4ad9d53abdc6ef0415f9b7f120234100e5c95b/0.jpg","time_slot":"2016-05-23T23:00:00Z","recorded_at":"2016-05-23T23:05:51Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173218383,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/aa8435d4e083915b96d4813dc969554b3ba8cec5/0.jpg","time_slot":"2016-05-23T23:10:00Z","recorded_at":"2016-05-23T23:12:51Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173218389,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/4a794505873b26e068256ddcb99b80be50cf152c/0.jpg","time_slot":"2016-05-23T23:20:00Z","recorded_at":"2016-05-23T23:20:54Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173222901,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/2419fd9aad3293a1322b45c8671caa471cf8f931/0.jpg","time_slot":"2016-05-23T23:30:00Z","recorded_at":"2016-05-23T23:35:04Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173225033,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/fad4d39d397276fac908a80fe56cc08453adcf9b/0.jpg","time_slot":"2016-05-23T23:40:00Z","recorded_at":"2016-05-23T23:42:35Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173227360,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/617337f02ca3bf3e7cf14b4fef6e75d7c6356d79/0.jpg","time_slot":"2016-05-23T23:50:00Z","recorded_at":"2016-05-23T23:51:45Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173233089,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/9c78aee48c75b8441a4d6fcfde11b4a92631df11/0.jpg","time_slot":"2016-05-24T00:00:00Z","recorded_at":"2016-05-24T00:05:03Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173233095,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/b49ef1b5b9fb33f1835c2a165c422059705bc5a9/0.jpg","time_slot":"2016-05-24T00:10:00Z","recorded_at":"2016-05-24T00:19:11Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173236951,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/bf60b31559277b2139fdb7949c14f598af35adcf/0.jpg","time_slot":"2016-05-24T00:20:00Z","recorded_at":"2016-05-24T00:28:51Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0},{"id":173236957,"url":"https://hubstaff-production.s3.amazonaws.com/screenshots/61188/2016/21/112761/e89877b6237e22e5dd54dd2eaf2e752290c775b7/0.jpg","time_slot":"2016-05-24T00:30:00Z","recorded_at":"2016-05-24T00:37:09Z","user_id":61188,"project_id":112761,"offset_x":0,"offset_y":0,"width":1440,"height":900,"screen":0}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:27:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/task/find_task.yml
+++ b/spec/vcr/task/find_task.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/tasks/716530
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 404
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '33'
+      status:
+      - 404 Not Found
+      cache-control:
+      - no-cache
+      date:
+      - Tue, 02 Aug 2016 20:31:09 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - a7059ce4-9c00-4ed9-aec4-83fde35670ac
+      x-runtime:
+      - '0.045170'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":"Could not find record"}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:31:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/task/tasks.yml
+++ b/spec/vcr/task/tasks.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/tasks?offset=0&projects%5Bprojects%5D=112761
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '58'
+      status:
+      - 400 Bad Request
+      cache-control:
+      - no-cache
+      date:
+      - Tue, 02 Aug 2016 20:36:49 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - cb9efd5b-1c71-4c46-98a9-771350c912a5
+      x-runtime:
+      - '0.009744'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":"projects: must be an array separated by commas"}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:36:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/task/tasks_offset.yml
+++ b/spec/vcr/task/tasks_offset.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/tasks?offset=0&projects%5Boffset%5D=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '58'
+      status:
+      - 400 Bad Request
+      cache-control:
+      - no-cache
+      date:
+      - Tue, 02 Aug 2016 20:34:45 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - fa0e1fb1-4338-4dca-b37b-b93850a02363
+      x-runtime:
+      - '0.017309'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":"projects: must be an array separated by commas"}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:34:45 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/task/tasks_project.yml
+++ b/spec/vcr/task/tasks_project.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/tasks?offset=0&projects%5Bprojects%5D=112761
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '58'
+      status:
+      - 400 Bad Request
+      cache-control:
+      - no-cache
+      date:
+      - Tue, 02 Aug 2016 20:36:50 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - a098f9fe-f23f-41e0-a80e-1951055fc783
+      x-runtime:
+      - '0.014447'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":"projects: must be an array separated by commas"}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 20:36:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/user/find_user.yml
+++ b/spec/vcr/user/find_user.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/users/61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '118'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 18:18:56 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - b644faa4-48ab-4437-9a7f-984120b297b5
+      etag:
+      - W/"0b0d049f68cfc1b318758892f64db28a"
+      x-runtime:
+      - '0.062407'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"user":{"id":61188,"name":"Raymond Cudjoe","last_activity":"2016-05-24T01:25:21Z","email":"rkcudjoe@hookengine.com"}}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:18:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/user/find_user_orgs.yml
+++ b/spec/vcr/user/find_user_orgs.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/users/61188/organizations?offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '92'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 18:23:06 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 42961418-4344-486d-936f-94d3b26760d1
+      etag:
+      - W/"7bd7378ce220cf2765d17e49f0b1d957"
+      x-runtime:
+      - '0.041132'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","last_activity":"2016-05-24T01:25:21Z"}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:23:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/user/find_user_projects.yml
+++ b/spec/vcr/user/find_user_projects.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/users/61188/projects?offset=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 18:18:57 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 76dc57be-4674-49de-b14d-3890e75f54f5
+      etag:
+      - W/"b49d2caa1abe08f1c56c8ebbfc82f346"
+      x-runtime:
+      - '0.137179'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"projects":[{"id":112761,"name":"Build Ruby Gem","last_activity":"2016-05-24T01:25:21Z","status":"Active","description":null},{"id":120320,"name":"Hubstaff
+        API tutorial","last_activity":null,"status":"Active","description":null}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:18:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/user/users.yml
+++ b/spec/vcr/user/users.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/users?offset=0&organization_memberships=false&project_memberships=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '121'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 18:24:33 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - fd818e4c-29f3-4fa2-ac34-7e01b45927f0
+      etag:
+      - W/"1603f05314cc5decff4b89e0fec0315b"
+      x-runtime:
+      - '0.787310'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"users":[{"id":61188,"name":"Raymond Cudjoe","last_activity":"2016-05-24T01:25:21Z","email":"rkcudjoe@hookengine.com"}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:24:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/user/users_orgs.yml
+++ b/spec/vcr/user/users_orgs.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/users?offset=0&organization_memberships=true&project_memberships=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 18:24:32 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 9e1803d7-d1fe-4c30-8af1-aaa43fb67edb
+      etag:
+      - W/"45becd6485ca45daf5a3e2628c31e593"
+      x-runtime:
+      - '0.774572'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"users":[{"id":61188,"name":"Raymond Cudjoe","last_activity":"2016-05-24T01:25:21Z","email":"rkcudjoe@hookengine.com","organizations":[{"id":27572,"name":"Hook
+        Engine","last_activity":"2016-05-24T01:25:21Z"}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:24:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/user/users_projects.yml
+++ b/spec/vcr/user/users_projects.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/users?offset=0&organization_memberships=false&project_memberships=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Tue, 02 Aug 2016 18:24:31 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - d1a178d2-5d89-48c1-92b3-33b9db97202d
+      etag:
+      - W/"0d5814cc0517157a25b1a567af486c63"
+      x-runtime:
+      - '0.795639'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"users":[{"id":61188,"name":"Raymond Cudjoe","last_activity":"2016-05-24T01:25:21Z","email":"rkcudjoe@hookengine.com","projects":[{"id":112761,"name":"Build
+        Ruby Gem","last_activity":"2016-05-24T01:25:21Z","status":"Active"},{"id":120320,"name":"Hubstaff
+        API tutorial","last_activity":null,"status":"Active"}]}]}'
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:24:31 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_my.yml
+++ b/spec/vcr/weekly/weekly_my.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/my
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '20'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:25:42 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - e46fae93-16b4-4427-92eb-47b152b6fb4b
+      etag:
+      - W/"0002b794793eb0ac3c6eba0af45cdec5"
+      x-runtime:
+      - '0.032727'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"organizations":[]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:25:43 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_my_date.yml
+++ b/spec/vcr/weekly/weekly_my_date.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/my?date=2016-05-24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:25:54 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 73067b42-780f-4890-8943-9c30c5ac93f7
+      etag:
+      - W/"e0fa3a37b3ed03a41929d1bff2a7f3b4"
+      x-runtime:
+      - '0.042655'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874}]}]}]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:25:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_my_org.yml
+++ b/spec/vcr/weekly/weekly_my_org.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/my?date=2016-05-24&organizations=27572
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:26:02 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - c133cc5a-56a7-4ce0-b4be-549718d2505d
+      etag:
+      - W/"e0fa3a37b3ed03a41929d1bff2a7f3b4"
+      x-runtime:
+      - '0.031979'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874}]}]}]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:26:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_my_project.yml
+++ b/spec/vcr/weekly/weekly_my_project.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/my?date=2016-05-24&projects=112761
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:26:10 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - dd841145-a322-4c27-a02f-cf9a47ed5404
+      etag:
+      - W/"e0fa3a37b3ed03a41929d1bff2a7f3b4"
+      x-runtime:
+      - '0.030535'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874}]}]}]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:26:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_my_user.yml
+++ b/spec/vcr/weekly/weekly_my_user.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/my?date=2016-05-24&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:26:17 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 1f47c604-bdb3-426d-85d6-923f6cd7a8c4
+      etag:
+      - W/"e0fa3a37b3ed03a41929d1bff2a7f3b4"
+      x-runtime:
+      - '0.042495'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874}]}]}]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:26:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_team.yml
+++ b/spec/vcr/weekly/weekly_team.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/team
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      content-length:
+      - '20'
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:24:43 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 8283bf08-2fed-443d-a439-451698265f32
+      etag:
+      - W/"0002b794793eb0ac3c6eba0af45cdec5"
+      x-runtime:
+      - '0.049871'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"organizations":[]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:24:44 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_team_date.yml
+++ b/spec/vcr/weekly/weekly_team_date.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/team?date=2016-05-24
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:24:57 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - d1d5cee7-efd3-45ca-bda0-54bfa8623fbd
+      etag:
+      - W/"e0fa3a37b3ed03a41929d1bff2a7f3b4"
+      x-runtime:
+      - '0.065788'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874}]}]}]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:24:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_team_org.yml
+++ b/spec/vcr/weekly/weekly_team_org.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/team?date=2016-05-24&organizations=27572
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:25:07 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - f5f1d1eb-4da0-4b67-a358-6dd76875eb54
+      etag:
+      - W/"e0fa3a37b3ed03a41929d1bff2a7f3b4"
+      x-runtime:
+      - '0.050684'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874}]}]}]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:25:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_team_project.yml
+++ b/spec/vcr/weekly/weekly_team_project.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/team?date=2016-05-24&projects=112761
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:25:16 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 1d0a0c6b-479b-4455-b96d-de2d733af893
+      etag:
+      - W/"e0fa3a37b3ed03a41929d1bff2a7f3b4"
+      x-runtime:
+      - '0.049578'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874}]}]}]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:25:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/weekly/weekly_team_user.yml
+++ b/spec/vcr/weekly/weekly_team_user.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubstaff.com/v1/weekly/team?date=2016-05-24&users=61188
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Hubstaff-Ruby v0.0.1
+      Auth-Token:
+      - 5WZ1SCto37HBhH-AR1jn0kC3FXROO4b39CREMSyt_1U
+      App-Token:
+      - 1u6rQ6kuB46U8kSYAXRPDaBvvAiB7GPMMxZVLii79KQ
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      connection:
+      - close
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      status:
+      - 200 OK
+      cache-control:
+      - max-age=0, private, must-revalidate
+      date:
+      - Wed, 03 Aug 2016 02:25:26 GMT
+      vary:
+      - Origin
+      strict-transport-security:
+      - max-age=31536000
+      x-request-id:
+      - 22d59266-c2fe-4377-bc85-bd10b5e52369
+      etag:
+      - W/"e0fa3a37b3ed03a41929d1bff2a7f3b4"
+      x-runtime:
+      - '0.034230'
+      x-rack-cache:
+      - miss
+      x-powered-by:
+      - Phusion Passenger 5.0.25
+      server:
+      - nginx/1.8.1 + Phusion Passenger 5.0.25
+      via:
+      - 1.1 vegur
+    body:
+      encoding: ASCII-8BIT
+      string: '{"organizations":[{"id":27572,"name":"Hook Engine","duration":7874,"users":[{"id":61188,"name":"Raymond
+        Cudjoe","duration":7874,"dates":[{"date":"2016-05-23","duration":7874}]}]}]}'
+    http_version: 
+  recorded_at: Wed, 03 Aug 2016 02:25:27 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
1. Removed ENV dependency from Client methods. 
2. `#initialize` method now only accepts application token as argument.
3. New `#authenticate` method authenticates user and assigns auth_token to client instance.
4. All specs now utilize the VCR gem and have associated "recordings" via yml files.